### PR TITLE
ORION-3575 Fix inconsistencies of interface fulfillment

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,15 +14,15 @@ Building The Provider
 Clone repository to: `$GOPATH/src/github.com/doublecloud/terraform-provider-doublecloud`
 
 ```sh
-$ mkdir -p $GOPATH/src/github.com/doublecloud; cd $GOPATH/src/github.com/doublecloud
-$ git clone git@github.com:doublecloud/terraform-provider-doublecloud`
+mkdir -p $GOPATH/src/github.com/doublecloud; cd $GOPATH/src/github.com/doublecloud
+git clone git@github.com:doublecloud/terraform-provider-doublecloud`
 ```
 
 Enter the provider directory and build the provider
 
 ```sh
-$ cd $GOPATH/src/github.com/doublecloud/terraform-provider-doublecloud`
-$ make build
+cd $GOPATH/src/github.com/doublecloud/terraform-provider-doublecloud`
+make build
 ```
 
 Using the provider
@@ -31,14 +31,14 @@ If you're building the provider, follow the instructions to [install it as a plu
 An example of using an installed provider from local directory: 
 
 Write following config into  `~/.terraformrc`
-```
+```ini
 provider_installation {
    dev_overrides {
     "doublecloud/doublecloud" = "/path/to/local/provider"
   }
 
    direct {}
- }
+}
 ```
 
 Developing the Provider
@@ -49,16 +49,16 @@ If you wish to work on the provider, you'll first need [Go](http://www.golang.or
 To compile the provider, run `make build`. This will build the provider and put the provider binary in the `$GOPATH/bin` directory.
 
 ```sh
-$ make build
+make build
 ...
-$ $GOPATH/bin/terraform-provider-doublecloud
+$GOPATH/bin/terraform-provider-doublecloud
 ...
 ```
 
 In order to test the provider, you can simply run `make test`.
 
 ```sh
-$ make test
+make test
 ```
 
 In order to run the full suite of [Acceptance tests](https://www.terraform.io/docs/extend/testing/acceptance-tests/index.html), run `make testacc`.
@@ -66,5 +66,5 @@ In order to run the full suite of [Acceptance tests](https://www.terraform.io/do
 *Note:* Acceptance tests create real resources, and often cost money to run.
 
 ```sh
-$ make testacc
+make testacc
 ```

--- a/internal/provider/clickhouse_cluster_resource.go
+++ b/internal/provider/clickhouse_cluster_resource.go
@@ -37,8 +37,8 @@ type clickhouseClusterModel struct {
 	// Access            *clickhouseAccess           `tfsdk:"resources"`
 	// Hide encryption due to deprecation
 	// Encryption *DataEncryptionModel `tfsdk:"encryption"`
-	NetworkId  types.String         `tfsdk:"network_id"`
-	Config     *clickhouseConfig    `tfsdk:"config"`
+	NetworkId types.String      `tfsdk:"network_id"`
+	Config    *clickhouseConfig `tfsdk:"config"`
 
 	// TODO: support mw
 	// https://github.com/doublecloud/api/blob/main/doublecloud/v1/maintenance.proto
@@ -232,8 +232,8 @@ func clickhouseConfigCompressionMethodValidator() validator.String {
 }
 
 // Ensure provider defined types fully satisfy framework interfaces.
-var _ resource.Resource = &TransferEndpointResource{}
-var _ resource.ResourceWithImportState = &TransferEndpointResource{}
+var _ resource.Resource = &ClickhouseClusterResource{}
+var _ resource.ResourceWithImportState = &ClickhouseClusterResource{}
 
 func NewClickhouseClusterResource() resource.Resource {
 	return &ClickhouseClusterResource{}

--- a/internal/provider/transfer_resource.go
+++ b/internal/provider/transfer_resource.go
@@ -24,8 +24,8 @@ import (
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
-var _ resource.Resource = &TransferEndpointResource{}
-var _ resource.ResourceWithImportState = &TransferEndpointResource{}
+var _ resource.Resource = &TransferResource{}
+var _ resource.ResourceWithImportState = &TransferResource{}
 
 func NewTransferResource() resource.Resource {
 	return &TransferResource{}
@@ -316,6 +316,10 @@ func (r *TransferResource) Delete(ctx context.Context, req resource.DeleteReques
 		resp.Diagnostics.AddError("failed to delete", err.Error())
 	}
 	err = op.Wait(ctx)
+	if err != nil {
+		resp.Diagnostics.AddError("failed to wait for delete completion", err.Error())
+		return
+	}
 
 	tflog.Trace(ctx, fmt.Sprintf("deleted endpoint: %s", data.Id))
 }


### PR DESCRIPTION
Some `resource.Resouce` implementation referred to `TransferEndpointResource` instead of an actual resource defined in a file with a type assertion. This is fixed.

In `README.md`, extra `$` signs are removed from bash scripts.