### PR TITLE
ORION-3611. Add an example terraform project for pg2ch transfer

### DIFF
--- a/example_projects/transfer/.gitignore
+++ b/example_projects/transfer/.gitignore
@@ -1,0 +1,4 @@
+.terraform.lock.hcl
+terraform.tfstate
+terraform.tfstate.backup
+.terraform

--- a/example_projects/transfer/pg2ch/README.md
+++ b/example_projects/transfer/pg2ch/README.md
@@ -1,0 +1,34 @@
+# Example terraform to create a transfer from PostgreSQL to ClickHouse
+
+The example in this directory illustrates how a transfer from PostgreSQL to ClickHouse can be created using DoubleCloud public Terraform.
+
+Before running `terraform apply`, replace the variables and values in the Terraform files with the appropriate ones to enable access to databases in your environment.
+
+## Contents
+
+### `versions.tf`
+
+Contains definition of the DoubleCloud public Terraform provider and the following important block:
+
+```ini
+provider "doublecloud" {
+  authorized_key = file("authorized_key.json")
+}
+```
+
+The `authorized_key.json` is an authentication file required to use a service account. See [DoubleCloud documentation](https://double.cloud/docs/en/public-api/tutorials/transfer-api-quickstart) for the instructions on how to obtain this file.
+
+### `variables.tf`
+
+Contains several Terraform variables. See their descriptions and usage for details.
+
+### `transfer.tf`
+
+Contains definitions of three resources:
+
+* `"doublecloud_transfer_endpoint" "sample-pg2ch-source"` is the source endpoint
+    * `hosts` and other parameters should be replaced with the actual values enabling access to a PostgreSQL instance. The instance itself should be created separately, for example, using [AWS RDS provider](https://registry.terraform.io/modules/terraform-aws-modules/rds/aws/latest), or manually.
+* `"doublecloud_transfer_endpoint" "sample-pg2ch-target"` is the target endpoint
+    * `address` and other connection parameters should be replaced with the values enabling access to a ClickHouse instance. The example uses a managed ClickHouse instance. Such an instance can be created using a `doublecloud_clickhouse_cluster` resource or manually. This is better be made separately in advance, because ClickHouse cluster creation takes long time, and the credentials to access a newly-created cluster should be obtained manually (they are not displayed in Terraform for security reasons).
+* `"doublecloud_transfer" "sample-pg2ch"` is the transfer itself
+    * Set `activated` to `true` to activate a transfer automatically on creation.

--- a/example_projects/transfer/pg2ch/transfer.tf
+++ b/example_projects/transfer/pg2ch/transfer.tf
@@ -1,0 +1,46 @@
+resource "doublecloud_transfer_endpoint" "sample-pg2ch-source" {
+  name = "sample-pg2ch-source"
+  project_id = var.project_id
+  settings {
+    postgres_source {
+      connection {
+        on_premise {
+          hosts = [
+            "mypostgresql.host"
+          ]
+          port = 5432
+        }
+      }
+      database = "postgres"
+      user = "postgres"
+      password = var.postgresql_postgres_password
+    }
+  }
+}
+
+resource "doublecloud_transfer_endpoint" "sample-pg2ch-target" {
+  name = "sample-pg2ch-target"
+  project_id = var.project_id
+  settings {
+    clickhouse_target {
+      clickhouse_cleanup_policy = "DROP"
+      connection {
+        address {
+            cluster_id = "chcexampleexampleexa"
+        }
+        database = "default"
+        password = var.clickhouse_admin_password
+        user = "admin"
+      }
+    }
+  }
+}
+
+resource "doublecloud_transfer" "sample-pg2ch" {
+  name = "sample-pg2ch"
+  project_id = var.project_id
+  source = doublecloud_transfer_endpoint.sample-pg2ch-source.id
+  target = doublecloud_transfer_endpoint.sample-pg2ch-target.id
+  type = "SNAPSHOT_ONLY"
+  activated = false
+}

--- a/example_projects/transfer/pg2ch/variables.tf
+++ b/example_projects/transfer/pg2ch/variables.tf
@@ -1,0 +1,18 @@
+variable project_id {
+  type = string
+  default = "dogfood"
+  description = "ID of the DoubleCloud project in which to create resources"
+}
+
+variable postgresql_postgres_password {
+  type = string
+  default = "password"
+  description = "Password of the user 'postgres' in the source PostgreSQL cluster"
+}
+
+variable clickhouse_admin_password {
+  type = string
+  default = "password"
+  sensitive = true
+  description = "Password of the user 'admin' in the target ClickHouse cluster"
+}

--- a/example_projects/transfer/pg2ch/versions.tf
+++ b/example_projects/transfer/pg2ch/versions.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    doublecloud = {
+      source = "registry.terraform.io/doublecloud/doublecloud"
+    }
+  }
+}
+
+provider "doublecloud" {
+  authorized_key = file("authorized_key.json")
+}

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,0 +1,11 @@
+terraform {
+  required_providers {
+    doublecloud = {
+      source = "registry.terraform.io/doublecloud/doublecloud"
+    }
+  }
+}
+
+provider "doublecloud" {
+  authorized_key = file("authorized_key.json") # See https://double.cloud/docs/en/public-api/tutorials/transfer-api-quickstart on how to obtain this file
+}

--- a/examples/resources/doublecloud_transfer/resource.tf
+++ b/examples/resources/doublecloud_transfer/resource.tf
@@ -1,0 +1,8 @@
+resource "doublecloud_transfer" "sample-pg2ch" {
+  name = "sample-pg2ch"
+  project_id = var.project_id
+  source = doublecloud_transfer_endpoint.sample-pg2ch-source.id
+  target = doublecloud_transfer_endpoint.sample-pg2ch-target.id
+  type = "SNAPSHOT_ONLY"
+  activated = false
+}

--- a/examples/resources/doublecloud_transfer_endpoint/resource.tf
+++ b/examples/resources/doublecloud_transfer_endpoint/resource.tf
@@ -1,0 +1,37 @@
+resource "doublecloud_transfer_endpoint" "sample-pg2ch-source" {
+  name = "sample-pg2ch-source"
+  project_id = var.project_id
+  settings {
+    postgres_source {
+      connection {
+        on_premise {
+          hosts = [
+            "mypostgresql.host"
+          ]
+          port = 5432
+        }
+      }
+      database = "postgres"
+      user = "postgres"
+      password = var.postgresql_postgres_password
+    }
+  }
+}
+
+resource "doublecloud_transfer_endpoint" "sample-pg2ch-target" {
+  name = "sample-pg2ch-target"
+  project_id = var.project_id
+  settings {
+    clickhouse_target {
+      clickhouse_cleanup_policy = "DROP"
+      connection {
+        address {
+            cluster_id = "chcexampleexampleexa"
+        }
+        database = "default"
+        password = var.clickhouse_admin_password
+        user = "admin"
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add an example whole Terraform project for a pg2ch transfer.

Add an `examples` directory with example usages of some `transfer` resources (copy-pasted from an example project).

The documentation itself is *not* regenerated in this PR, because the changes would be huge and would affect not only the modified examples, but other providers as well.