### PR TITLE
ORION-3575 Add transformers to `transfer_resource`

### DIFF
--- a/examples/resources/doublecloud_transfer/resource.tf
+++ b/examples/resources/doublecloud_transfer/resource.tf
@@ -5,4 +5,15 @@ resource "doublecloud_transfer" "sample-pg2ch" {
   target = doublecloud_transfer_endpoint.sample-pg2ch-target.id
   type = "SNAPSHOT_ONLY"
   activated = false
+  transformation = {
+    transformers = [
+      {
+        dbt = {
+          git_repository_link = "https://github.com/doublecloud/tests-clickhouse-dbt.git"
+          profile_name = "my_clickhouse_profile"
+          operation = "run"
+        }
+      },
+    ]
+  }
 }

--- a/internal/provider/transfer_resource.go
+++ b/internal/provider/transfer_resource.go
@@ -2,7 +2,9 @@ package provider
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
@@ -35,17 +37,6 @@ type TransferResource struct {
 	sdk *dcsdk.SDK
 	// endpointService *dcgentf.EndpointServiceClient
 	transferService *dcgentf.TransferServiceClient
-}
-
-type TransferResourceModel struct {
-	Id          types.String `tfsdk:"id"`
-	ProjectID   types.String `tfsdk:"project_id"`
-	Name        types.String `tfsdk:"name"`
-	Description types.String `tfsdk:"description"`
-	Source      types.String `tfsdk:"source"`
-	Target      types.String `tfsdk:"target"`
-	Type        types.String `tfsdk:"type"`
-	Activated   types.Bool   `tfsdk:"activated"`
 }
 
 func (r *TransferResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -83,8 +74,7 @@ func (r *TransferResource) Schema(ctx context.Context, req resource.SchemaReques
 				Default:             stringdefault.StaticString(""),
 			},
 			"type": schema.StringAttribute{
-				Optional: true,
-				// Computed:            true,
+				Optional:            true,
 				MarkdownDescription: "Transfer type",
 				Validators:          []validator.String{transferTypeValidator()},
 				PlanModifiers: []planmodifier.String{
@@ -111,6 +101,7 @@ func (r *TransferResource) Schema(ctx context.Context, req resource.SchemaReques
 				Default:             booldefault.StaticBool(false),
 				MarkdownDescription: "Activation of transfer",
 			},
+			"transformation": transferTransformationSchema(),
 		},
 	}
 }
@@ -132,35 +123,10 @@ func (r *TransferResource) Configure(ctx context.Context, req resource.Configure
 	}
 
 	r.sdk = sdk
-	// r.endpointService = r.sdk.Transfer().Endpoint()
 	r.transferService = r.sdk.Transfer().Transfer()
 }
 
-func createTransferRequest(m *TransferResourceModel) (*transfer.CreateTransferRequest, diag.Diagnostics) {
-	var diag diag.Diagnostics
-
-	rq := &transfer.CreateTransferRequest{}
-	rq.Name = m.Name.ValueString()
-	rq.Description = m.Description.ValueString()
-	rq.ProjectId = m.ProjectID.ValueString()
-	rq.SourceId = m.Source.ValueString()
-	rq.TargetId = m.Target.ValueString()
-	rq.Type = transfer.TransferType(transfer.TransferType_value[m.Type.ValueString()])
-
-	if diag.HasError() {
-		return nil, diag
-	}
-
-	return rq, nil
-}
-
-func deleteTransferRequest(m *TransferResourceModel) (*transfer.DeleteTransferRequest, diag.Diagnostics) {
-	return &transfer.DeleteTransferRequest{
-		TransferId: m.Id.ValueString(),
-	}, diag.Diagnostics{}
-}
-
-func (r *TransferResource) setActivation(ctx context.Context, m *TransferResourceModel) diag.Diagnostics {
+func (r *TransferResource) setActivation(ctx context.Context, m *transferResourceModel) diag.Diagnostics {
 	var diags diag.Diagnostics
 	var dcOp *doublecloud.Operation
 	var err error
@@ -196,7 +162,7 @@ func (r *TransferResource) setActivation(ctx context.Context, m *TransferResourc
 }
 
 func (r *TransferResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var data *TransferResourceModel
+	var data *transferResourceModel
 
 	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
@@ -205,23 +171,23 @@ func (r *TransferResource) Create(ctx context.Context, req resource.CreateReques
 		return
 	}
 
-	rq, diag := createTransferRequest(data)
+	rq, diag := data.CreateRequest()
 	if diag.HasError() {
 		resp.Diagnostics.Append(diag...)
 		return
 	}
 	rs, err := r.transferService.Create(ctx, rq)
 	if err != nil {
-		resp.Diagnostics.AddError("failed to create", err.Error())
+		resp.Diagnostics.AddError("failed to call Create", err.Error())
 		return
 	}
 	op, err := r.sdk.WrapOperation(rs, err)
 	if err != nil {
-		resp.Diagnostics.AddError("failed to create", err.Error())
+		resp.Diagnostics.AddError("failed to wrap Create operation", err.Error())
 	}
 	err = op.Wait(ctx)
 	if err != nil {
-		resp.Diagnostics.AddError("failed to create", err.Error())
+		resp.Diagnostics.AddError("failed to Create", err.Error())
 	}
 
 	data.Id = types.StringValue(op.ResourceId())
@@ -233,7 +199,7 @@ func (r *TransferResource) Create(ctx context.Context, req resource.CreateReques
 }
 
 func (r *TransferResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	var data *TransferResourceModel
+	var data *transferResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
@@ -249,39 +215,41 @@ func (r *TransferResource) Read(ctx context.Context, req resource.ReadRequest, r
 		resp.Diagnostics.AddError("failed to get", err.Error())
 		return
 	}
-	data.Name = types.StringValue(rs.Name)
-	data.Description = types.StringValue(rs.Description)
-	data.Source = types.StringValue(rs.Source.Id)
-	data.Target = types.StringValue(rs.Target.Id)
-	data.Type = types.StringValue(rs.Type.String())
+	diags := data.parse(rs)
+	if diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
 func (r *TransferResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	var data *TransferResourceModel
+	var data *transferResourceModel
 
 	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 
-	rs, err := r.transferService.Update(ctx, &transfer.UpdateTransferRequest{
-		TransferId:  data.Id.ValueString(),
-		Description: data.Description.ValueString(),
-		Name:        data.Name.ValueString(),
-	})
+	rq, diag := data.UpdateRequest()
+	if diag.HasError() {
+		resp.Diagnostics.Append(diag...)
+		return
+	}
+
+	rs, err := r.transferService.Update(ctx, rq)
 	if err != nil {
-		resp.Diagnostics.AddError("failed to update", err.Error())
+		resp.Diagnostics.AddError("failed to call Update", err.Error())
 		return
 	}
 	op, err := r.sdk.WrapOperation(rs, err)
 	if err != nil {
-		resp.Diagnostics.AddError("failed to update", err.Error())
+		resp.Diagnostics.AddError("failed to wrap Update operation", err.Error())
 		return
 	}
 	err = op.Wait(ctx)
 	if err != nil {
-		resp.Diagnostics.AddError("failed to update", err.Error())
+		resp.Diagnostics.AddError("failed to Update", err.Error())
 		return
 	}
 
@@ -292,7 +260,7 @@ func (r *TransferResource) Update(ctx context.Context, req resource.UpdateReques
 }
 
 func (r *TransferResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	var data *TransferResourceModel
+	var data *transferResourceModel
 
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
@@ -301,7 +269,7 @@ func (r *TransferResource) Delete(ctx context.Context, req resource.DeleteReques
 		return
 	}
 
-	rq, diag := deleteTransferRequest(data)
+	rq, diag := data.DeleteRequest()
 	if diag.HasError() {
 		resp.Diagnostics.Append(diag...)
 		return
@@ -334,4 +302,554 @@ func transferTypeValidator() validator.String {
 		names[i] = v
 	}
 	return stringvalidator.OneOfCaseInsensitive(names...)
+}
+
+type transferResourceModel struct {
+	Id             types.String            `tfsdk:"id"`
+	ProjectID      types.String            `tfsdk:"project_id"`
+	Name           types.String            `tfsdk:"name"`
+	Description    types.String            `tfsdk:"description"`
+	Source         types.String            `tfsdk:"source"`
+	Target         types.String            `tfsdk:"target"`
+	Type           types.String            `tfsdk:"type"`
+	Activated      types.Bool              `tfsdk:"activated"`
+	Transformation *transferTransformation `tfsdk:"transformation"`
+}
+
+type requestType int
+
+const (
+	requestTypeCreate requestType = 0
+	requestTypeUpdate requestType = 1
+)
+
+func (m *transferResourceModel) CreateRequest() (*transfer.CreateTransferRequest, diag.Diagnostics) {
+	r := new(transfer.CreateTransferRequest)
+	var diags diag.Diagnostics
+
+	r.Name = m.Name.ValueString()
+	r.Description = m.Description.ValueString()
+	r.ProjectId = m.ProjectID.ValueString()
+	r.SourceId = m.Source.ValueString()
+	r.TargetId = m.Target.ValueString()
+	r.Type = transfer.TransferType(transfer.TransferType_value[m.Type.ValueString()])
+	if m.Transformation != nil {
+		r.Transformation = new(transfer.Transformation)
+		diags.Append(m.Transformation.convert(requestTypeCreate, r.Transformation)...)
+	}
+
+	return r, diags
+}
+
+func (m *transferResourceModel) parse(t *transfer.Transfer) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	m.Id = types.StringValue(t.GetId())
+	m.ProjectID = types.StringValue(t.GetProjectId())
+	m.Name = types.StringValue(t.GetName())
+	m.Description = types.StringValue(t.GetDescription())
+	m.Source = types.StringValue(t.GetSource().GetId())
+	m.Target = types.StringValue(t.GetTarget().GetId())
+	m.Type = types.StringValue(t.GetType().String())
+
+	if t.GetTransformation() != nil {
+		if m.Transformation == nil {
+			m.Transformation = new(transferTransformation)
+		}
+		diags.Append(m.Transformation.parse(t.Transformation)...)
+	} else {
+		m.Transformation = nil
+	}
+
+	return diags
+}
+
+func (m *transferResourceModel) UpdateRequest() (*transfer.UpdateTransferRequest, diag.Diagnostics) {
+	r := new(transfer.UpdateTransferRequest)
+	var diags diag.Diagnostics
+
+	r.TransferId = m.Id.ValueString()
+	r.Name = m.Name.ValueString()
+	r.Description = m.Description.ValueString()
+	if m.Transformation != nil {
+		r.Transformation = new(transfer.Transformation)
+		diags.Append(m.Transformation.convert(requestTypeUpdate, r.Transformation)...)
+	}
+
+	return r, diags
+}
+
+func (m *transferResourceModel) DeleteRequest() (*transfer.DeleteTransferRequest, diag.Diagnostics) {
+	return &transfer.DeleteTransferRequest{
+		TransferId: m.Id.ValueString(),
+	}, nil
+}
+
+type transferTransformation struct {
+	Transformers []transferTransformer `tfsdk:"transformers"`
+}
+
+func transferTransformationSchema() schema.Attribute {
+	return schema.SingleNestedAttribute{
+		Attributes: map[string]schema.Attribute{
+			"transformers": transferTransformerSchema(),
+		},
+		Optional: true,
+	}
+}
+
+func (m *transferTransformation) convert(rqt requestType, r *transfer.Transformation) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if len(m.Transformers) > 0 {
+		r.Transformers = make([]*transfer.Transformer, len(m.Transformers))
+		for i := range m.Transformers {
+			r.Transformers[i] = new(transfer.Transformer)
+			diags.Append(m.Transformers[i].convert(rqt, r.Transformers[i])...)
+		}
+	}
+
+	return diags
+}
+
+func (m *transferTransformation) parse(t *transfer.Transformation) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	tTransformers := t.GetTransformers()
+	if len(tTransformers) > 0 {
+		if len(m.Transformers) == 0 {
+			m.Transformers = make([]transferTransformer, 0)
+		}
+		for i := range tTransformers {
+			if i >= len(m.Transformers) {
+				m.Transformers = append(m.Transformers, *new(transferTransformer))
+			}
+			diags.Append(m.Transformers[i].parse(tTransformers[i])...)
+		}
+	} else {
+		m.Transformers = nil
+	}
+
+	return diags
+}
+
+type transferTransformer struct {
+	ReplacePrimaryKey *transferTransformerReplacePrimaryKey `tfsdk:"replace_primary_key"`
+	ConvertToString   *transferTransformerConvertToString   `tfsdk:"convert_to_string"`
+	DBT               *transferTransformerDBT               `tfsdk:"dbt"`
+	TableSplitter     *transferTransformerTableSplitter     `tfsdk:"table_splitter"`
+}
+
+func transferTransformerSchema() schema.Attribute {
+	return schema.ListNestedAttribute{
+		NestedObject: schema.NestedAttributeObject{
+			Attributes: map[string]schema.Attribute{
+				"replace_primary_key": transferTransformerReplacePrimaryKeySchema(),
+				"convert_to_string":   transferTransformerConvertToStringSchema(),
+				"dbt":                 transferTransformerDBTSchema(),
+				"table_splitter":      transferTransformerTableSplitterSchema(),
+			},
+		},
+		Optional: true,
+	}
+}
+
+func (m *transferTransformer) convert(rqt requestType, r *transfer.Transformer) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	switch {
+	case m.ReplacePrimaryKey != nil:
+		tr := new(transfer.ReplacePrimaryKeyTransformer)
+		diags.Append(m.ReplacePrimaryKey.convert(rqt, tr)...)
+		r.Transformer = &transfer.Transformer_ReplacePrimaryKey{ReplacePrimaryKey: tr}
+	case m.ConvertToString != nil:
+		tr := new(transfer.ToStringTransformer)
+		diags.Append(m.ConvertToString.convert(rqt, tr)...)
+		r.Transformer = &transfer.Transformer_ConvertToString{ConvertToString: tr}
+	case m.DBT != nil:
+		tr := new(transfer.DBTTransformer)
+		diags.Append(m.DBT.convert(rqt, tr)...)
+		r.Transformer = &transfer.Transformer_Dbt{Dbt: tr}
+	case m.TableSplitter != nil:
+		tr := new(transfer.TableSplitterTransformer)
+		m.TableSplitter.convert(rqt, tr)
+		r.Transformer = &transfer.Transformer_TableSplitterTransformer{TableSplitterTransformer: tr}
+	default:
+		diags.Append(diag.NewErrorDiagnostic("a transformer is present, but not set to any oneof value", ""))
+	}
+
+	return diags
+}
+
+func (m *transferTransformer) parse(t *transfer.Transformer) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	switch {
+	case t.GetReplacePrimaryKey() != nil:
+		if m.ReplacePrimaryKey == nil {
+			m.clear()
+			m.ReplacePrimaryKey = new(transferTransformerReplacePrimaryKey)
+		}
+		diags.Append(m.ReplacePrimaryKey.parse(t.GetReplacePrimaryKey())...)
+	case t.GetConvertToString() != nil:
+		if m.ConvertToString == nil {
+			m.clear()
+			m.ConvertToString = new(transferTransformerConvertToString)
+		}
+		diags.Append(m.ConvertToString.parse(t.GetConvertToString())...)
+	case t.GetDbt() != nil:
+		if m.DBT == nil {
+			m.clear()
+			m.DBT = new(transferTransformerDBT)
+		}
+		diags.Append(m.DBT.parse(t.GetDbt())...)
+	case t.GetTableSplitterTransformer() != nil:
+		if m.TableSplitter == nil {
+			m.clear()
+			m.TableSplitter = new(transferTransformerTableSplitter)
+		}
+		diags.Append(m.TableSplitter.parse(t.GetTableSplitterTransformer())...)
+	default:
+		m.clear()
+	}
+
+	return diags
+}
+
+func (m *transferTransformer) clear() {
+	m.ReplacePrimaryKey = nil
+	m.ConvertToString = nil
+	m.DBT = nil
+	m.TableSplitter = nil
+}
+
+type transferTransformerReplacePrimaryKey struct {
+	Tables *transferTransformerTablesFilter `tfsdk:"tables"`
+	Keys   []types.String                   `tfsdk:"keys"`
+}
+
+func transferTransformerReplacePrimaryKeySchema() schema.Attribute {
+	return schema.SingleNestedAttribute{
+		Attributes: map[string]schema.Attribute{
+			"keys": schema.ListAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				MarkdownDescription: "Columns to mark as PRIMARY KEYs.",
+			},
+			"tables": transferTransformerTablesFilterSchema(),
+		},
+		Optional:            true,
+		MarkdownDescription: "Replace the set of columns marked as PRIMARY KEYs.",
+	}
+}
+
+func (m *transferTransformerReplacePrimaryKey) convert(rqt requestType, r *transfer.ReplacePrimaryKeyTransformer) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	r.Keys = convertSliceTFStrings(m.Keys)
+	if m.Tables != nil {
+		r.Tables = new(transfer.TablesFilter)
+		diags.Append(m.Tables.convert(rqt, r.Tables)...)
+	}
+
+	return diags
+}
+
+func (m *transferTransformerReplacePrimaryKey) parse(t *transfer.ReplacePrimaryKeyTransformer) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if tables := t.GetTables(); tables != nil {
+		if m.Tables == nil {
+			m.Tables = new(transferTransformerTablesFilter)
+		}
+		diags.Append(m.Tables.parse(tables)...)
+	} else {
+		m.Tables = nil
+	}
+
+	m.Keys = convertSliceToTFStrings(t.GetKeys())
+
+	return diags
+}
+
+type transferTransformerTablesFilter struct {
+	Include []types.String `tfsdk:"include"`
+	Exclude []types.String `tfsdk:"exclude"`
+}
+
+func transferTransformerTablesFilterSchema() schema.Attribute {
+	return schema.SingleNestedAttribute{
+		Attributes: map[string]schema.Attribute{
+			"include": schema.ListAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				MarkdownDescription: "Included tables (regular expressions). Start every name with `^` and finish with `$` to avoid unexpected side effects.",
+			},
+			"exclude": schema.ListAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				MarkdownDescription: "Excluded tables (regular expressions). Start every name with `^` and finish with `$` to avoid unexpected side effects.",
+			},
+		},
+		Optional:            true,
+		MarkdownDescription: "Tables.",
+	}
+}
+
+func (m *transferTransformerTablesFilter) convert(rqt requestType, r *transfer.TablesFilter) diag.Diagnostics {
+	r.IncludeTables = convertSliceTFStrings(m.Include)
+	r.ExcludeTables = convertSliceTFStrings(m.Exclude)
+
+	return nil
+}
+
+func (m *transferTransformerTablesFilter) parse(t *transfer.TablesFilter) diag.Diagnostics {
+	m.Include = convertSliceToTFStrings(t.GetIncludeTables())
+	m.Exclude = convertSliceToTFStrings(t.GetExcludeTables())
+
+	return nil
+}
+
+type transferTransformerConvertToString struct {
+	Tables  *transferTransformerTablesFilter  `tfsdk:"tables"`
+	Columns *transferTransformerColumnsFilter `tfsdk:"columns"`
+}
+
+func transferTransformerConvertToStringSchema() schema.Attribute {
+	return schema.SingleNestedAttribute{
+		Attributes: map[string]schema.Attribute{
+			"tables":  transferTransformerTablesFilterSchema(),
+			"columns": transferTransformerColumnsFilterSchema(),
+		},
+		Optional:            true,
+		MarkdownDescription: "Convert columns' values to strings.",
+	}
+}
+
+func (m *transferTransformerConvertToString) convert(rqt requestType, r *transfer.ToStringTransformer) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if m.Tables != nil {
+		r.Tables = new(transfer.TablesFilter)
+		diags.Append(m.Tables.convert(rqt, r.Tables)...)
+	}
+	if m.Columns != nil {
+		r.Columns = new(transfer.ColumnsFilter)
+		diags.Append(m.Columns.convert(rqt, r.Columns)...)
+	}
+
+	return diags
+}
+
+func (m *transferTransformerConvertToString) parse(t *transfer.ToStringTransformer) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if tables := t.GetTables(); tables != nil {
+		if m.Tables == nil {
+			m.Tables = new(transferTransformerTablesFilter)
+		}
+		diags.Append(m.Tables.parse(tables)...)
+	} else {
+		m.Tables = nil
+	}
+
+	if columns := t.GetColumns(); columns != nil {
+		if m.Columns == nil {
+			m.Columns = new(transferTransformerColumnsFilter)
+		}
+		diags.Append(m.Columns.parse(columns)...)
+	} else {
+		m.Columns = nil
+	}
+
+	return diags
+}
+
+type transferTransformerColumnsFilter struct {
+	Include []types.String `tfsdk:"include"`
+	Exclude []types.String `tfsdk:"exclude"`
+}
+
+func transferTransformerColumnsFilterSchema() schema.Attribute {
+	return schema.SingleNestedAttribute{
+		Attributes: map[string]schema.Attribute{
+			"include": schema.ListAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				MarkdownDescription: "Included columns (regular expressions). Start every name with `^` and finish with `$` to avoid unexpected side effects.",
+			},
+			"exclude": schema.ListAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				MarkdownDescription: "Excluded columns (regular expressions). Start every name with `^` and finish with `$` to avoid unexpected side effects.",
+			},
+		},
+		Optional: true,
+	}
+}
+
+func (m *transferTransformerColumnsFilter) convert(rqt requestType, r *transfer.ColumnsFilter) diag.Diagnostics {
+	r.IncludeColumns = convertSliceTFStrings(m.Include)
+	r.ExcludeColumns = convertSliceTFStrings(m.Exclude)
+
+	return nil
+}
+
+func (m *transferTransformerColumnsFilter) parse(t *transfer.ColumnsFilter) diag.Diagnostics {
+	m.Include = convertSliceToTFStrings(t.GetIncludeColumns())
+	m.Exclude = convertSliceToTFStrings(t.GetExcludeColumns())
+
+	return nil
+}
+
+type transferTransformerDBT struct {
+	GitRepositoryLink types.String `tfsdk:"git_repository_link"`
+	GitBranch         types.String `tfsdk:"git_branch"`
+	ProfileName       types.String `tfsdk:"profile_name"`
+	Operation         types.String `tfsdk:"operation"` // is a oneof
+}
+
+func transferTransformerDBTSchema() schema.Attribute {
+	return schema.SingleNestedAttribute{
+		Attributes: map[string]schema.Attribute{
+			"git_repository_link": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "A link to a git repository with a DBT project. Must start with `https://`. The root directory of the repository must contain a `dbt_project.yml` file.",
+			},
+			"git_branch": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "A branch or a tag of the git repository with the DBT project.",
+				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"profile_name": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "The name for a profile which will be created automatically using the settings of the destination endpoint. The name must match the `profile` property in the `dbt_project.yml` file.",
+			},
+			"operation": schema.StringAttribute{
+				Optional:            true,
+				Validators:          []validator.String{stringvalidator.OneOf(transferTransformerDBTOperationValidatorOneofValues()...)},
+				MarkdownDescription: "Operation; for example, `run`.",
+			},
+		},
+		Optional:            true,
+		MarkdownDescription: "Run DBT after snapshot finish.",
+	}
+}
+
+func transferTransformerDBTOperationValidatorOneofValues() []string {
+	result := make([]string, 0)
+	for opcode := range transfer.DBTTransformer_Operation_name {
+		if opcode == int32(transfer.DBTTransformer_OPERATION_UNSPECIFIED) {
+			continue
+		}
+		result = append(result, opcodeToOperation(transfer.DBTTransformer_Operation(opcode)))
+	}
+	return result
+}
+
+func opcodeToOperation(opcode transfer.DBTTransformer_Operation) string {
+	result := transfer.DBTTransformer_Operation_name[int32(opcode)]
+	result = strings.ToLower(strings.TrimPrefix(result, "OPERATION_"))
+	return result
+}
+
+func (m *transferTransformerDBT) convert(rqt requestType, r *transfer.DBTTransformer) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	r.GitRepositoryLink = m.GitRepositoryLink.ValueString()
+	r.GitBranch = m.GitBranch.ValueString()
+	r.ProfileName = m.ProfileName.ValueString()
+
+	opcode, err := operationToOpcode(m.Operation.ValueString())
+	if err != nil {
+		diags.AddAttributeError(path.Root("operation"), "unsupported operation type", err.Error())
+		return diags
+	}
+	r.Operation = opcode
+
+	return diags
+}
+
+func operationToOpcode(operation string) (transfer.DBTTransformer_Operation, error) {
+	if len(operation) == 0 {
+		return transfer.DBTTransformer_OPERATION_UNSPECIFIED, errors.New("DBT operation must be set")
+	}
+
+	operationEnumString := "OPERATION_" + strings.ToUpper(operation)
+
+	opcode, opValid := transfer.DBTTransformer_Operation_value[operationEnumString]
+	if !opValid {
+		return transfer.DBTTransformer_OPERATION_UNSPECIFIED, fmt.Errorf("unknown DBT operation %q", operation)
+	}
+
+	return transfer.DBTTransformer_Operation(opcode), nil
+}
+
+func (m *transferTransformerDBT) parse(t *transfer.DBTTransformer) diag.Diagnostics {
+	m.GitRepositoryLink = types.StringValue(t.GetGitRepositoryLink())
+	if b := t.GetGitBranch(); len(b) > 0 {
+		m.GitBranch = types.StringValue(b)
+	} else {
+		m.GitBranch = types.StringNull()
+	}
+	m.ProfileName = types.StringValue(t.GetProfileName())
+	m.Operation = types.StringValue(opcodeToOperation(t.GetOperation()))
+
+	return nil
+}
+
+type transferTransformerTableSplitter struct {
+	Tables   *transferTransformerTablesFilter `tfsdk:"tables"`
+	Columns  []types.String                   `tfsdk:"columns"`
+	Splitter types.String                     `tfsdk:"splitter"`
+}
+
+func transferTransformerTableSplitterSchema() schema.Attribute {
+	return schema.SingleNestedAttribute{
+		Attributes: map[string]schema.Attribute{
+			"columns": schema.ListAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				MarkdownDescription: "Columns with values to use as a new table name.",
+			},
+			"splitter": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "A string separating the parts of the new table name.",
+			},
+			"tables": transferTransformerTablesFilterSchema(),
+		},
+		Optional:            true,
+		MarkdownDescription: "Replace the name of the table to a value composed of values of columns of a row.",
+	}
+}
+
+func (m *transferTransformerTableSplitter) convert(rqt requestType, r *transfer.TableSplitterTransformer) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	r.Columns = convertSliceTFStrings(m.Columns)
+	r.Splitter = m.Splitter.ValueString()
+	if m.Tables != nil {
+		r.Tables = new(transfer.TablesFilter)
+		diags.Append(m.Tables.convert(rqt, r.Tables)...)
+	}
+
+	return diags
+}
+
+func (m *transferTransformerTableSplitter) parse(t *transfer.TableSplitterTransformer) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if tables := t.GetTables(); tables != nil {
+		if m.Tables == nil {
+			m.Tables = new(transferTransformerTablesFilter)
+		}
+		diags.Append(m.Tables.parse(tables)...)
+	} else {
+		m.Tables = nil
+	}
+
+	m.Columns = convertSliceToTFStrings(t.GetColumns())
+	m.Splitter = types.StringValue(t.GetSplitter())
+
+	return diags
 }


### PR DESCRIPTION
Add support of `Transformation` and `Transformer`s to the Terraform provider for transfer.

Refactor the Terraform provider in question slightly to support multilevel structure of `Transformer`s.