### PR TITLE
ORION-3605 Support `parser` in `kafka_source` `doublecloud_transfer_endpoint` resource

### DIFF
--- a/internal/provider/transfer_endpoint_kafka.go
+++ b/internal/provider/transfer_endpoint_kafka.go
@@ -2,12 +2,16 @@ package provider
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/doublecloud/go-genproto/doublecloud/transfer/v1"
 	"github.com/doublecloud/go-genproto/doublecloud/transfer/v1/endpoint"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
-	"github.com/hashicorp/terraform-plugin-framework/provider/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 )
@@ -16,7 +20,33 @@ type endpointKafkaSourceSettings struct {
 	Connection *endpointKafkaConnectionOptions `tfsdk:"connection"`
 	Auth       *endpointKafkaAuth              `tfsdk:"auth"`
 	TopicName  types.String                    `tfsdk:"topic_name"`
-	// TODO: Parser
+	Parser     *endpointKafkaParser            `tfsdk:"parser"`
+}
+
+func (m *endpointKafkaSourceSettings) parse(e *endpoint.KafkaSource) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if auth := e.GetAuth(); auth != nil {
+		if m.Auth == nil {
+			m.Auth = new(endpointKafkaAuth)
+		}
+		diags.Append(m.Auth.parse(auth)...)
+	} else {
+		m.Auth = nil
+	}
+	parseTransferEndpointKafkaConnection(e.Connection, m.Connection)
+	m.TopicName = types.StringValue(e.TopicName)
+
+	if prsr := e.GetParser(); prsr != nil {
+		if m.Parser == nil {
+			m.Parser = new(endpointKafkaParser)
+		}
+		diags.Append(m.Parser.parse(prsr)...)
+	} else {
+		m.Parser = nil
+	}
+
+	return diags
 }
 
 type endpointKafkaConnectionOptions struct {
@@ -29,17 +59,387 @@ type endpointKafkaAuth struct {
 	NoAuth *endpointKafkAuthNoAuth `tfsdk:"no_auth"`
 }
 
+func (m *endpointKafkaAuth) parse(e *endpoint.KafkaAuth) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	switch {
+	case e.GetNoAuth() != nil:
+		m.SASL = nil
+		m.NoAuth = new(endpointKafkAuthNoAuth)
+	case e.GetSasl() != nil:
+		m.NoAuth = nil
+		if m.SASL == nil {
+			m.SASL = new(endpointKafkaAuthSASL)
+		}
+		diags.Append(m.SASL.parse(e.GetSasl())...)
+	default:
+		diags.Append(diag.NewErrorDiagnostic("unknown auth type", fmt.Sprintf("%v", e.GetSecurity())))
+	}
+
+	return diags
+}
+
+func (m *endpointKafkaAuth) convert(r *endpoint.KafkaAuth) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	switch {
+	case m.NoAuth != nil:
+		r.Security = &endpoint.KafkaAuth_NoAuth{NoAuth: new(endpoint.NoAuth)}
+	case m.SASL != nil:
+		sasl := new(endpoint.KafkaSaslSecurity)
+		diags.Append(m.SASL.convert(sasl)...)
+		r.Security = &endpoint.KafkaAuth_Sasl{Sasl: sasl}
+	}
+
+	return diags
+}
+
+type endpointKafkAuthNoAuth struct{}
+
 type endpointKafkaAuthSASL struct {
 	User      types.String `tfsdk:"user"`
 	Password  types.String `tfsdk:"password"`
 	Mechanism types.String `tfsdk:"mechanism"`
 }
 
-type endpointKafkAuthNoAuth struct{}
+func (m *endpointKafkaAuthSASL) parse(e *endpoint.KafkaSaslSecurity) diag.Diagnostics {
+	m.User = types.StringValue(e.GetUser())
+	if e.GetMechanism() != endpoint.KafkaMechanism_KAFKA_MECHANISM_UNSPECIFIED {
+		m.Mechanism = types.StringValue(e.GetMechanism().String())
+	}
+
+	return nil
+}
+
+func (m *endpointKafkaAuthSASL) convert(r *endpoint.KafkaSaslSecurity) diag.Diagnostics {
+	r.User = m.User.ValueString()
+	if len(m.Password.ValueString()) > 0 {
+		r.Password = &endpoint.Secret{Value: &endpoint.Secret_Raw{Raw: m.Password.ValueString()}}
+	}
+	r.Mechanism = endpoint.KafkaMechanism(endpoint.KafkaMechanism_value[m.Mechanism.ValueString()])
+
+	return nil
+}
 
 type endpointOnPremiseKafka struct {
 	BrokerUrls []types.String   `tfsdk:"broker_urls"`
 	TLSMode    *endpointTLSMode `tfsdk:"tls_mode"`
+}
+
+type endpointKafkaParser struct {
+	JSON *transferParserGeneric `tfsdk:"json"`
+	TSKV *transferParserGeneric `tfsdk:"tskv"`
+}
+
+func endpointKafkaParserSchema() schema.Block {
+	return schema.SingleNestedBlock{
+		Blocks: map[string]schema.Block{
+			"json": transferParserGenericSchema(),
+			"tskv": transferParserGenericSchema(),
+		},
+	}
+}
+
+func (m *endpointKafkaParser) parse(e *endpoint.Parser) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	switch {
+	case e.GetJsonParser() != nil:
+		m.TSKV = nil
+		if m.JSON == nil {
+			m.JSON = new(transferParserGeneric)
+		}
+		diags.Append(m.JSON.parse(e.GetJsonParser())...)
+	case e.GetTskvParser() != nil:
+		m.JSON = nil
+		if m.TSKV == nil {
+			m.TSKV = new(transferParserGeneric)
+		}
+		diags.Append(m.TSKV.parse(e.GetTskvParser())...)
+	default:
+		diags.Append(diag.NewErrorDiagnostic("unknown parser type", fmt.Sprintf("%v", e.GetParser())))
+	}
+
+	return diags
+}
+
+func (m *endpointKafkaParser) convert(r *endpoint.Parser) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	switch {
+	case m.JSON != nil:
+		prsr := new(endpoint.GenericParserCommon)
+		diags.Append(m.JSON.convert(prsr)...)
+		r.Parser = &endpoint.Parser_JsonParser{JsonParser: prsr}
+	case m.TSKV != nil:
+		prsr := new(endpoint.GenericParserCommon)
+		diags.Append(m.TSKV.convert(prsr)...)
+		r.Parser = &endpoint.Parser_TskvParser{TskvParser: prsr}
+	}
+
+	return diags
+}
+
+type transferParserGeneric struct {
+	Schema          *transferParserSchema `tfsdk:"schema"`
+	NullKeysAllowed types.Bool            `tfsdk:"null_keys_allowed"`
+	AddRestColumn   types.Bool            `tfsdk:"add_rest_column"`
+}
+
+func transferParserGenericSchema() schema.Block {
+	return schema.SingleNestedBlock{
+		Attributes: map[string]schema.Attribute{
+			"null_keys_allowed": schema.BoolAttribute{
+				Optional: true,
+			},
+			"add_rest_column": schema.BoolAttribute{
+				Optional: true,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"schema": transferParserSchemaSchema(),
+		},
+	}
+}
+
+func (m *transferParserGeneric) parse(e *endpoint.GenericParserCommon) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	m.NullKeysAllowed = types.BoolValue(e.GetNullKeysAllowed())
+	m.AddRestColumn = types.BoolValue(e.GetAddRestColumn())
+	if sch := e.GetDataSchema(); sch != nil {
+		if m.Schema == nil {
+			m.Schema = new(transferParserSchema)
+		}
+		diags.Append(m.Schema.parse(sch)...)
+	}
+
+	return diags
+}
+
+func (m *transferParserGeneric) convert(r *endpoint.GenericParserCommon) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if m.Schema != nil {
+		r.DataSchema = new(endpoint.DataSchema)
+		diags.Append(m.Schema.convert(r.DataSchema)...)
+	}
+	r.NullKeysAllowed = m.NullKeysAllowed.ValueBool()
+	r.AddRestColumn = m.AddRestColumn.ValueBool()
+
+	return diags
+
+}
+
+type transferParserSchema struct {
+	JSON   *transferParserSchemaJSON   `tfsdk:"json"`
+	Fields *transferParserSchemaFields `tfsdk:"fields"`
+}
+
+func transferParserSchemaSchema() schema.Block {
+	return schema.SingleNestedBlock{
+		Blocks: map[string]schema.Block{
+			"json":   transferParserSchemaJSONSchema(),
+			"fields": transferParserSchemaFieldsSchema(),
+		},
+	}
+}
+
+func (m *transferParserSchema) parse(e *endpoint.DataSchema) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	switch {
+	case e.GetFields() != nil:
+		m.JSON = nil
+		if m.Fields == nil {
+			m.Fields = new(transferParserSchemaFields)
+		}
+		diags.Append(m.Fields.parse(e.GetFields())...)
+	case e.GetJsonFields() != "":
+		m.Fields = nil
+		if m.JSON == nil {
+			m.JSON = new(transferParserSchemaJSON)
+		}
+		diags.Append(m.JSON.parse(e.GetJsonFields())...)
+	default:
+		diags.Append(diag.NewErrorDiagnostic("unknown schema type", fmt.Sprintf("%v", e.GetSchema())))
+	}
+
+	return diags
+}
+
+func (m *transferParserSchema) convert(r *endpoint.DataSchema) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	switch {
+	case m.Fields != nil:
+		fl := new(endpoint.FieldList)
+		diags.Append(m.Fields.convert(fl)...)
+		r.Schema = &endpoint.DataSchema_Fields{Fields: fl}
+	case m.JSON != nil:
+		jsn := new(string)
+		diags.Append(m.JSON.convert(jsn)...)
+		r.Schema = &endpoint.DataSchema_JsonFields{JsonFields: *jsn}
+	}
+
+	return diags
+}
+
+type transferParserSchemaJSON struct {
+	Fields types.String `tfsdk:"fields"`
+}
+
+func transferParserSchemaJSONSchema() schema.Block {
+	return schema.SingleNestedBlock{
+		Attributes: map[string]schema.Attribute{
+			"fields": schema.StringAttribute{
+				Optional: true,
+			},
+		},
+	}
+}
+
+func (m *transferParserSchemaJSON) parse(json string) diag.Diagnostics {
+	m.Fields = types.StringValue(json)
+	return nil
+}
+
+func (m *transferParserSchemaJSON) convert(r *string) diag.Diagnostics {
+	*r = m.Fields.ValueString()
+	return nil
+}
+
+type transferParserSchemaFields struct {
+	Fields []*transferParserSchemaFieldsField `tfsdk:"field"`
+}
+
+func transferParserSchemaFieldsSchema() schema.Block {
+	return schema.SingleNestedBlock{
+		Blocks: map[string]schema.Block{
+			"field": schema.ListNestedBlock{
+				NestedObject: transferParserSchemaFieldsFieldSchema(),
+			},
+		},
+	}
+}
+
+func (m *transferParserSchemaFields) parse(e *endpoint.FieldList) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	flds := e.GetFields()
+	if len(flds) == 0 {
+		m.Fields = nil
+		return nil
+	}
+
+	if len(m.Fields) == 0 {
+		m.Fields = make([]*transferParserSchemaFieldsField, len(flds))
+	}
+	for i := range flds {
+		if len(m.Fields) <= i {
+			m.Fields = append(m.Fields, new(transferParserSchemaFieldsField))
+		}
+		diags.Append(m.Fields[i].parse(flds[i])...)
+	}
+
+	return diags
+}
+
+func (m *transferParserSchemaFields) convert(r *endpoint.FieldList) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if len(m.Fields) == 0 {
+		return nil
+	}
+
+	r.Fields = make([]*endpoint.ColSchema, len(m.Fields))
+	for i := range m.Fields {
+		r.Fields[i] = new(endpoint.ColSchema)
+		diags.Append(m.Fields[i].convert(r.Fields[i])...)
+	}
+
+	return diags
+}
+
+type transferParserSchemaFieldsField struct {
+	Name     types.String `tfsdk:"name"`
+	Type     types.String `tfsdk:"type"` // enum
+	Key      types.Bool   `tfsdk:"key"`
+	Required types.Bool   `tfsdk:"required"`
+	Path     types.String `tfsdk:"path"`
+}
+
+func transferParserSchemaFieldsFieldSchema() schema.NestedBlockObject {
+	return schema.NestedBlockObject{
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
+				Optional: true,
+			},
+			"type": schema.StringAttribute{
+				Optional: true,
+			},
+			"key": schema.BoolAttribute{
+				Optional: true,
+			},
+			"required": schema.BoolAttribute{
+				Optional: true,
+			},
+			"path": schema.StringAttribute{
+				Optional: true,
+			},
+		},
+	}
+}
+
+func (m *transferParserSchemaFieldsField) parse(e *endpoint.ColSchema) diag.Diagnostics {
+	m.Name = types.StringValue(e.GetName())
+	m.Type = types.StringValue(transferParserSchemaFieldsFieldTypeFromEnum(e.GetType()))
+	m.Key = types.BoolValue(e.GetKey())
+	m.Required = types.BoolValue(e.GetRequired())
+	if pth := e.GetPath(); len(pth) > 0 {
+		m.Path = types.StringValue(pth)
+	} else {
+		m.Path = types.StringNull()
+	}
+	return nil
+}
+
+func transferParserSchemaFieldsFieldTypeFromEnum(typ endpoint.ColumnType) string {
+	result := endpoint.ColumnType_name[int32(typ)]
+	result = strings.ToLower(result)
+	return result
+}
+
+func (m *transferParserSchemaFieldsField) convert(r *endpoint.ColSchema) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	r.Name = m.Name.ValueString()
+	typ, err := transferParserSchemaFieldsFieldTypeToEnum(m.Type.ValueString())
+	if err != nil {
+		diags.Append(diag.NewErrorDiagnostic(err.Error(), ""))
+		return diags
+	}
+	r.Type = typ
+	r.Key = m.Key.ValueBool()
+	r.Required = m.Required.ValueBool()
+	r.Path = m.Path.ValueString()
+
+	return diags
+}
+
+func transferParserSchemaFieldsFieldTypeToEnum(typ string) (endpoint.ColumnType, error) {
+	if len(typ) == 0 {
+		return endpoint.ColumnType_COLUMN_TYPE_UNSPECIFIED, fmt.Errorf("column type must be set")
+	}
+
+	operationEnumString := strings.ToUpper(typ)
+
+	typE, typValid := endpoint.ColumnType_value[operationEnumString]
+	if !typValid {
+		return endpoint.ColumnType_COLUMN_TYPE_UNSPECIFIED, fmt.Errorf("unknown column type %q", typ)
+	}
+
+	return endpoint.ColumnType(typE), nil
 }
 
 type endpointKafkaTargetSettings struct {
@@ -113,11 +513,17 @@ func transferEndpointKafkaAuthSchemaBlock() schema.SingleNestedBlock {
 			"sasl": schema.SingleNestedBlock{
 				MarkdownDescription: "Authentication with SASL",
 				Attributes: map[string]schema.Attribute{
-					"user":     schema.StringAttribute{Optional: true},
-					"password": schema.StringAttribute{Optional: true, Sensitive: true},
+					"user": schema.StringAttribute{
+						Optional: true,
+					},
+					"password": schema.StringAttribute{
+						Optional:  true,
+						Sensitive: true,
+					},
 					"mechanism": schema.StringAttribute{
-						Optional:   true,
-						Validators: []validator.String{transferEndpointKafkaMechanismValidator()},
+						Optional:      true,
+						Validators:    []validator.String{transferEndpointKafkaMechanismValidator()},
+						PlanModifiers: []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
 					},
 				},
 			},
@@ -139,6 +545,7 @@ func transferEndpointKafkaSourceSchema() schema.Block {
 		Blocks: map[string]schema.Block{
 			"connection": transferEndpointKafkaConnectionSchemaBlock(),
 			"auth":       transferEndpointKafkaAuthSchemaBlock(),
+			"parser":     endpointKafkaParserSchema(),
 		},
 	}
 }
@@ -208,46 +615,22 @@ func convertKafkaConnectionOptions(m *endpointKafkaConnectionOptions) (*endpoint
 	return options, diag
 }
 
-func convertKafkaAuth(m *endpointKafkaAuth) (*endpoint.KafkaAuth, diag.Diagnostics) {
-	var diag diag.Diagnostics
-
-	options := &endpoint.KafkaAuth{}
-
-	if m.NoAuth != nil {
-		options.Security = &endpoint.KafkaAuth_NoAuth{}
-	}
-	if m.SASL != nil && m.NoAuth == nil {
-		sasl := &endpoint.KafkaSaslSecurity{
-			User:     m.SASL.User.ValueString(),
-			Password: &endpoint.Secret{Value: &endpoint.Secret_Raw{Raw: m.SASL.Password.ValueString()}},
-		}
-		if !m.SASL.Mechanism.IsNull() {
-			sasl.Mechanism = endpoint.KafkaMechanism(endpoint.KafkaMechanism_value[m.SASL.Mechanism.ValueString()])
-		}
-
-		options.Security = &endpoint.KafkaAuth_Sasl{
-			Sasl: sasl,
-		}
-	}
-
-	if options.Security == nil {
-		diag.AddError("unknown auth", "required one of blocks: no_auth or sasl")
-	}
-	return options, diag
-}
-
 func kafkaSourceEndpointSettings(m *endpointKafkaSourceSettings) (*transfer.EndpointSettings_KafkaSource, diag.Diagnostics) {
 	settings := &transfer.EndpointSettings_KafkaSource{KafkaSource: &endpoint.KafkaSource{}}
 	var diags diag.Diagnostics
 
 	connection, d := convertKafkaConnectionOptions(m.Connection)
 	diags.Append(d...)
-	auth, d := convertKafkaAuth(m.Auth)
-	diags.Append(d...)
 	settings.KafkaSource.Connection = connection
-	settings.KafkaSource.Auth = auth
+	if m.Auth != nil {
+		settings.KafkaSource.Auth = new(endpoint.KafkaAuth)
+		diags.Append(m.Auth.convert(settings.KafkaSource.Auth)...)
+	}
 	settings.KafkaSource.TopicName = m.TopicName.ValueString()
-	// TODO: describe settings.KafkaSource.Parser
+	if m.Parser != nil {
+		settings.KafkaSource.Parser = new(endpoint.Parser)
+		diags.Append(m.Parser.convert(settings.KafkaSource.Parser)...)
+	}
 
 	return settings, diags
 }
@@ -319,36 +702,16 @@ func kafkaTargetEndpointSettings(m *endpointKafkaTargetSettings) (*transfer.Endp
 
 	settings.KafkaTarget.Connection, d = convertKafkaConnectionOptions(m.Connection)
 	diags.Append(d...)
-	settings.KafkaTarget.Auth, d = convertKafkaAuth(m.Auth)
-	diags.Append(d...)
+	if m.Auth != nil {
+		settings.KafkaTarget.Auth = new(endpoint.KafkaAuth)
+		diags.Append(m.Auth.convert(settings.KafkaTarget.Auth)...)
+	}
 	settings.KafkaTarget.TopicSettings, d = convertKafkaTargetTopicSettings(m.TopicSettings)
 	diags.Append(d...)
 	settings.KafkaTarget.Serializer, d = convertSerializer(m.Serializer)
 	diags.Append(d...)
 
 	return settings, diags
-}
-
-func parseTransferEndpointKafkaAuth(e *endpoint.KafkaAuth, m *endpointKafkaAuth) {
-	if e == nil {
-		m = nil
-	}
-
-	if no_auth := e.GetNoAuth(); no_auth != nil {
-		m = &endpointKafkaAuth{NoAuth: &endpointKafkAuthNoAuth{}}
-	}
-
-	if sasl := e.GetSasl(); sasl != nil {
-		if m == nil {
-			m = &endpointKafkaAuth{SASL: &endpointKafkaAuthSASL{}}
-		}
-		if !m.SASL.User.IsNull() {
-			m.SASL.User = types.StringValue(sasl.User)
-		}
-		if !m.SASL.Mechanism.IsNull() {
-			m.SASL.Mechanism = types.StringValue(sasl.Mechanism.String())
-		}
-	}
 }
 
 func parseTransferEndpointKafkaConnection(e *endpoint.KafkaConnectionOptions, m *endpointKafkaConnectionOptions) {
@@ -377,21 +740,17 @@ func parseTransferEndpointKafkaConnection(e *endpoint.KafkaConnectionOptions, m 
 	}
 }
 
-func parseTransferEndpointKafkaSource(ctx context.Context, e *endpoint.KafkaSource, c *endpointKafkaSourceSettings) diag.Diagnostics {
-	var diag diag.Diagnostics
-
-	parseTransferEndpointKafkaAuth(e.Auth, c.Auth)
-	parseTransferEndpointKafkaConnection(e.Connection, c.Connection)
-	c.TopicName = types.StringValue(e.TopicName)
-
-	return diag
-}
-
 func parseTransferEndpointKafkaTarget(ctx context.Context, e *endpoint.KafkaTarget, c *endpointKafkaTargetSettings) diag.Diagnostics {
-	var diag diag.Diagnostics
+	var diags diag.Diagnostics
 
-	parseTransferEndpointKafkaAuth(e.Auth, c.Auth)
 	parseTransferEndpointKafkaConnection(e.Connection, c.Connection)
+
+	if auth := e.GetAuth(); auth != nil {
+		if c.Auth == nil {
+			c.Auth = new(endpointKafkaAuth)
+		}
+		diags.Append(c.Auth.parse(auth)...)
+	}
 
 	if e.Serializer == nil {
 		c.Serializer = nil
@@ -435,5 +794,5 @@ func parseTransferEndpointKafkaTarget(ctx context.Context, e *endpoint.KafkaTarg
 		}
 	}
 
-	return diag
+	return diags
 }

--- a/internal/provider/transfer_endpoint_kafka_test.go
+++ b/internal/provider/transfer_endpoint_kafka_test.go
@@ -7,15 +7,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 )
 
-var (
-	testEKfSourceName string = fmt.Sprintf("%v-kafka-source", testPrefix)
-	testEKfTargetName string = fmt.Sprintf("%v-kafka-target", testPrefix)
+func TestAccTransferEndpointKafkaSource(t *testing.T) {
+	testEKfSourceName := fmt.Sprintf("%v-kafka-source", testPrefix)
+	testEKfSourceId := fmt.Sprintf("doublecloud_transfer_endpoint.%v", testEKfSourceName)
 
-	testEKfSourceId string = fmt.Sprintf("doublecloud_transfer_endpoint.%v", testEKfSourceName)
-	testEKfTargetId string = fmt.Sprintf("doublecloud_transfer_endpoint.%v", testEKfTargetName)
-)
-
-func TestAccTransferEndpointKafkaResource(t *testing.T) {
 	t.Parallel()
 
 	resource.Test(t, resource.TestCase{
@@ -24,124 +19,195 @@ func TestAccTransferEndpointKafkaResource(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccTransferEndpointResourceKafkaConfig(),
+				Config: fmt.Sprintf(`
+					resource "doublecloud_transfer_endpoint" %[1]q {
+						project_id = %[2]q
+						name = %[1]q
+						settings {
+							kafka_source {
+								connection {
+									cluster_id = "cluster-foo-id"
+								}
+								auth {
+									no_auth {}
+								}
+								topic_name = "orders"
+								parser {
+									tskv {
+										null_keys_allowed = false
+										add_rest_column = false
+										schema {
+											fields {
+												field {
+													name = "f1"
+													type = "int64"
+													key = false
+													required = false
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				`, testEKfSourceName, testProjectId),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(testEKfSourceId, "name", testEKfSourceName),
-					resource.TestCheckResourceAttr(testEKfSourceId, "settings.kafka_source.topic_name", "orders"),
+					resource.TestCheckResourceAttr(testEKfSourceId, "project_id", testProjectId),
 					resource.TestCheckResourceAttr(testEKfSourceId, "settings.kafka_source.connection.cluster_id", "cluster-foo-id"),
-					resource.TestCheckResourceAttr(testEKfTargetId, "settings.kafka_target.connection.cluster_id", "cluster-foo-id"),
+					resource.TestCheckResourceAttr(testEKfSourceId, "settings.kafka_source.topic_name", "orders"),
+					resource.TestCheckResourceAttr(testEKfSourceId, "settings.kafka_source.parser.tskv.null_keys_allowed", "false"),
+					resource.TestCheckResourceAttr(testEKfSourceId, "settings.kafka_source.parser.tskv.add_rest_column", "false"),
 				),
 			},
 			// Update and Read testing
 			{
-				Config: testAccTransferEndpointResourceKafkaModifiedConfig(),
+				Config: fmt.Sprintf(`
+					resource "doublecloud_transfer_endpoint" %[1]q {
+						project_id = %[2]q
+						name = %[1]q
+						settings {
+							kafka_source {
+								connection {
+									on_premise {					
+										broker_urls = ["host1-az1:9091", "host2-az2:9091"]
+										tls_mode {
+											ca_certificate = "<place-your-pem-here>"
+										}
+									}
+								}
+								auth {
+									sasl {
+										user = "sink-user"
+										password = "foobar123"
+										mechanism = "KAFKA_MECHANISM_SHA512"
+									}
+								}
+								topic_name = "orders"
+								parser {
+									json {
+										null_keys_allowed = true
+										add_rest_column = true
+										schema {
+											fields {
+												field {
+													name = "f1"
+													type = "int64"
+													key = false
+													required = false
+												}
+												field {
+													name = "f2"
+													type = "string"
+													key = false
+													required = false
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				`, testEKfSourceName, testProjectId),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttr(testEKfSourceId, "name", testEKfSourceName),
+					resource.TestCheckResourceAttr(testEKfSourceId, "project_id", testProjectId),
 					resource.TestCheckResourceAttr(testEKfSourceId, "settings.kafka_source.topic_name", "orders"),
-
 					resource.TestCheckResourceAttr(testEKfSourceId, "settings.kafka_source.connection.on_premise.tls_mode.ca_certificate", "<place-your-pem-here>"),
 					resource.TestCheckResourceAttr(testEKfSourceId, "settings.kafka_source.auth.sasl.user", "sink-user"),
 					resource.TestCheckResourceAttr(testEKfSourceId, "settings.kafka_source.auth.sasl.password", "foobar123"),
-
-					resource.TestCheckResourceAttr(testEKfTargetId, "settings.kafka_target.connection.cluster_id", "cluster-foo-id"),
-					resource.TestCheckResourceAttr(testEKfTargetId, "settings.kafka_target.auth.sasl.user", "sink-user"),
-					resource.TestCheckResourceAttr(testEKfTargetId, "settings.kafka_target.auth.sasl.password", "foobar123"),
+					resource.TestCheckResourceAttr(testEKfSourceId, "settings.kafka_source.topic_name", "orders"),
+					resource.TestCheckResourceAttr(testEKfSourceId, "settings.kafka_source.parser.json.null_keys_allowed", "true"),
+					resource.TestCheckResourceAttr(testEKfSourceId, "settings.kafka_source.parser.json.add_rest_column", "true"),
 				),
 			},
-			// Delete testing automatically occurs in TestCase
+			// Delete occurs automatically
 		},
 	})
 }
 
-func testAccTransferEndpointResourceKafkaConfig() string {
-	return fmt.Sprintf(`
-resource "doublecloud_transfer_endpoint" %[1]q {
-	project_id = %[3]q
-	name = %[1]q
-	settings {
-		kafka_source {
-			connection {
-				cluster_id = "cluster-foo-id"
-			}
-			auth {
-				no_auth {}
-			}
-			topic_name = "orders"
-		}
-	}
-}
+func TestAccTransferEndpointKafkaTarget(t *testing.T) {
+	testEKfTargetName := fmt.Sprintf("%v-kafka-target", testPrefix)
+	testEKfTargetId := fmt.Sprintf("doublecloud_transfer_endpoint.%v", testEKfTargetName)
 
-resource "doublecloud_transfer_endpoint" %[2]q {
-	project_id = %[3]q
-	name = %[2]q
-	settings {
-		kafka_target {
-			connection {
-				cluster_id = "cluster-foo-id"
-			}
-			auth {
-				no_auth {}
-			}
-			topic_settings {
-				topic_prefix = "prefix"
-			}
-			serializer {
-				auto {}
-			}
-		}
-	}
-}
-`, testEKfSourceName, testEKfTargetName, testProjectId)
-}
+	t.Parallel()
 
-func testAccTransferEndpointResourceKafkaModifiedConfig() string {
-	return fmt.Sprintf(`
-resource "doublecloud_transfer_endpoint" %[1]q {
-	project_id = %[3]q
-	name = %[1]q
-	settings {
-		kafka_source {
-			connection {
-				on_premise {					
-					broker_urls = ["host1-az1:9091", "host2-az2:9091"]
-					tls_mode {
-						ca_certificate = "<place-your-pem-here>"
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create and Read testing
+			{
+				Config: fmt.Sprintf(`
+					resource "doublecloud_transfer_endpoint" %[1]q {
+						project_id = %[2]q
+						name = %[1]q
+						settings {
+							kafka_target {
+								connection {
+									cluster_id = "cluster-foo-id"
+								}
+								auth {
+									no_auth {}
+								}
+								topic_settings {
+									topic_prefix = "prefix"
+								}
+								serializer {
+									auto {}
+								}
+							}
+						}
 					}
-				}
-			}
-			auth {
-				sasl {
-					user = "sink-user"
-					password = "foobar123"
-				}
-			}
-			topic_name = "orders"
-		}
-	}
-}
-
-resource "doublecloud_transfer_endpoint" %[2]q {
-	project_id = %[3]q
-	name = %[2]q
-	settings {
-		kafka_target {
-			connection {
-				cluster_id = "cluster-foo-id"
-			}
-			auth {
-				sasl {
-					user = "sink-user"
-					password = "foobar123"
-				}
-			}
-			topic_settings {
-				topic_prefix = "prefix"
-			}
-			serializer {
-				debezium {}
-			}
-		}
-	}
-}
-`, testEKfSourceName, testEKfTargetName, testProjectId)
+				`, testEKfTargetName, testProjectId),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(testEKfTargetId, "name", testEKfTargetName),
+					resource.TestCheckResourceAttr(testEKfTargetId, "project_id", testProjectId),
+					resource.TestCheckResourceAttr(testEKfTargetId, "settings.kafka_target.connection.cluster_id", "cluster-foo-id"),
+					resource.TestCheckResourceAttr(testEKfTargetId, "settings.kafka_target.topic_settings.topic_prefix", "prefix"),
+				),
+			},
+			// Update and Read testing
+			{
+				Config: fmt.Sprintf(`
+					resource "doublecloud_transfer_endpoint" %[1]q {
+						project_id = %[2]q
+						name = %[1]q
+						settings {
+							kafka_target {
+								connection {
+									cluster_id = "cluster-foo-id"
+								}
+								auth {
+									sasl {
+										user = "sink-user"
+										password = "foobar123"
+										mechanism = "KAFKA_MECHANISM_SHA512"
+									}
+								}
+								topic_settings {
+									topic_prefix = "prefix"
+								}
+								serializer {
+									debezium {}
+								}
+							}
+						}
+					}
+				`, testEKfTargetName, testProjectId),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(testEKfTargetId, "name", testEKfTargetName),
+					resource.TestCheckResourceAttr(testEKfTargetId, "project_id", testProjectId),
+					resource.TestCheckResourceAttr(testEKfTargetId, "settings.kafka_target.connection.cluster_id", "cluster-foo-id"),
+					resource.TestCheckResourceAttr(testEKfTargetId, "settings.kafka_target.auth.sasl.user", "sink-user"),
+					resource.TestCheckResourceAttr(testEKfTargetId, "settings.kafka_target.auth.sasl.password", "foobar123"),
+					resource.TestCheckResourceAttr(testEKfTargetId, "settings.kafka_target.auth.sasl.mechanism", "KAFKA_MECHANISM_SHA512"),
+					resource.TestCheckResourceAttr(testEKfTargetId, "settings.kafka_target.topic_settings.topic_prefix", "prefix"),
+				),
+			},
+			// Delete occurs automatically
+		},
+	})
 }

--- a/internal/provider/transfer_endpoint_resource.go
+++ b/internal/provider/transfer_endpoint_resource.go
@@ -463,7 +463,7 @@ func (data *TransferEndpointModel) parseTransferEndpoint(ctx context.Context, e 
 		if data.Settings.KafkaSource == nil {
 			data.Settings.KafkaSource = &endpointKafkaSourceSettings{}
 		}
-		diag.Append(parseTransferEndpointKafkaSource(ctx, settings, data.Settings.KafkaSource)...)
+		diag.Append(data.Settings.KafkaSource.parse(settings)...)
 	}
 	if settings := e.Settings.GetKafkaTarget(); settings != nil {
 		if data.Settings.KafkaTarget == nil {


### PR DESCRIPTION
Add the `parser` field to `doublecloud_transfer_endpoint` `kafka_source` resource. The new field is added as a block (and a set of underlying blocks).

`kafka_source` is modified and refactored in order for tests to complete properly. Tests are refactored to test target and source endpoint resources in different functions.