### PR TITLE
tests: move concurrency settings into github action jobs

### DIFF
--- a/.github/workflows/sweep.yml
+++ b/.github/workflows/sweep.yml
@@ -8,13 +8,13 @@ on:
 permissions:
   contents: read
 
-concurrency:
-  group: ci-acc-tests
-  cancel-in-progress: false
-
 jobs:
   sweep:
     runs-on: ubuntu-latest
+    concurrency:
+      group: ci-acc-tests
+      cancel-in-progress: false
+
     steps:
 
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,15 +2,14 @@ name: Tests
 
 on: [pull_request]
 
-concurrency:
-  group: ci-acc-tests
-  cancel-in-progress: false
-
 jobs:
   test:
     name: test
     runs-on: ubuntu-latest
     timeout-minutes: 125
+    concurrency:
+      group: ci-acc-tests
+      cancel-in-progress: false
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Temporary run acceptance tests under exclusive lock