### PR TITLE
feature: added `access` block with allow lists

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,11 +16,13 @@ jobs:
       - uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
+      - run: go mod download
+      - run: go mod vendor
+      - run: go build -v ./...
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.54
+          version: v1.54.2
           args: --timeout=10m
-      - run: go build -v ./...
       - name: run acceptance tests
         run: |
           echo $DC_KEY > authorized_key.json

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist
 authorized_key.json
 CHANGELOG.md
 terraform-provider-doublecloud
+env.fish

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,16 @@
+run:
+  deadline: 10m
+  modules-download-mode: vendor
+
+linters:
+  disable-all: true
+  enable:
+    - errcheck
+    - gofmt
+    - gosimple
+    - ineffassign
+    - misspell
+    - staticcheck
+    - unconvert
+    - unused
+    - vet

--- a/docs/data-sources/clickhouse.md
+++ b/docs/data-sources/clickhouse.md
@@ -3,12 +3,12 @@
 page_title: "doublecloud_clickhouse Data Source - terraform-provider-doublecloud"
 subcategory: ""
 description: |-
-  Clickhouse data soruce
+  Clickhouse data source
 ---
 
 # doublecloud_clickhouse (Data Source)
 
-Clickhouse data soruce
+Clickhouse data source
 
 
 
@@ -63,3 +63,5 @@ Read-Only:
 - `password` (String) Password for ClickHouse user
 - `tcp_port_secure` (Number) Port to connect using TCP/native protocol
 - `user` (String) ClickHouse user
+
+

--- a/docs/data-sources/kafka.md
+++ b/docs/data-sources/kafka.md
@@ -48,3 +48,5 @@ Optional:
 - `connection_string` (String) String to use in clients
 - `password` (String) Password for Apache Kafka® user
 - `user` (String) Apache Kafka® user
+
+

--- a/docs/data-sources/network.md
+++ b/docs/data-sources/network.md
@@ -27,3 +27,5 @@ Network data source
 - `id` (String) Network identifier
 - `ipv4_cidr_block` (String) The IPv4 network range for the subnet, in CIDR notation. For example, 10.0.0.0/16.
 - `region_id` (String) Region of network
+
+

--- a/docs/data-sources/network_connection.md
+++ b/docs/data-sources/network_connection.md
@@ -61,3 +61,5 @@ Read-Only:
 - `managed_network_url` (String) The URL of the managed GCP network
 - `name` (String) Name of this peering
 - `peer_network_url` (String) The URL of the peer network
+
+

--- a/docs/data-sources/transfer.md
+++ b/docs/data-sources/transfer.md
@@ -26,3 +26,5 @@ Transfer data source
 - `name` (String) Name of transfer
 - `status` (String) Status of transfer
 - `type` (String) Type of transfer
+
+

--- a/docs/resources/clickhouse_cluster.md
+++ b/docs/resources/clickhouse_cluster.md
@@ -32,6 +32,16 @@ resource "doublecloud_clickhouse_cluster" "example-clickhouse" {
     log_level = "LOG_LEVEL_TRACE"
     max_connections = 120
   }
+
+  access {
+    data_services = ["transfer"]
+    ipv4_cidr_blocks = [
+      {
+        value = "10.0.0.0/8"
+        description = "Office in Berlin"
+      }
+	  ]
+  }
 }
 ```
 
@@ -48,11 +58,46 @@ resource "doublecloud_clickhouse_cluster" "example-clickhouse" {
 
 ### Optional
 
+- `access` (Block, Optional) (see [below for nested schema](#nestedblock--access))
 - `config` (Block, Optional) (see [below for nested schema](#nestedblock--config))
 - `description` (String) Description of the ClickHouse cluster.
 - `id` (String) ID of the ClickHouse cluster.
 - `resources` (Block, Optional) (see [below for nested schema](#nestedblock--resources))
 - `version` (String) Version of ClickHouse DBMS.
+
+<a id="nestedblock--access"></a>
+### Nested Schema for `access`
+
+Optional:
+
+- `data_services` (List of String) List of allowed services
+- `ipv4_cidr_blocks` (Attributes List) (see [below for nested schema](#nestedatt--access--ipv4_cidr_blocks))
+- `ipv6_cidr_blocks` (Attributes List) (see [below for nested schema](#nestedatt--access--ipv6_cidr_blocks))
+
+<a id="nestedatt--access--ipv4_cidr_blocks"></a>
+### Nested Schema for `access.ipv4_cidr_blocks`
+
+Required:
+
+- `value` (String) CIDR block
+
+Optional:
+
+- `description` (String) Description of CIDR block
+
+
+<a id="nestedatt--access--ipv6_cidr_blocks"></a>
+### Nested Schema for `access.ipv6_cidr_blocks`
+
+Required:
+
+- `value` (String) CIDR block
+
+Optional:
+
+- `description` (String) Description of CIDR block
+
+
 
 <a id="nestedblock--config"></a>
 ### Nested Schema for `config`
@@ -130,3 +175,5 @@ Optional:
 - `replica_count` (Number) Number of hosts per shard.
 - `resource_preset_id` (String) ID of the preset for computational resources available to a host (CPU, memory, etc.).
 - `shard_count` (Number) Number of shards in the cluster.
+
+

--- a/docs/resources/kafka_cluster.md
+++ b/docs/resources/kafka_cluster.md
@@ -32,6 +32,16 @@ resource "doublecloud_clickhouse_kafka" "example-kafka" {
   schema_registry {
     enabled = false
   }
+
+  access {
+    data_services = ["transfer"]
+    ipv4_cidr_blocks = [
+      {
+        value = "10.0.0.0/8"
+        description = "Office in Berlin"
+      }
+	  ]
+  }
 }
 ```
 
@@ -48,6 +58,7 @@ resource "doublecloud_clickhouse_kafka" "example-kafka" {
 
 ### Optional
 
+- `access` (Block, Optional) (see [below for nested schema](#nestedblock--access))
 - `description` (String) Description of cluster
 - `resources` (Block, Optional) Resources of cluster (see [below for nested schema](#nestedblock--resources))
 - `schema_registry` (Block, Optional) Schema Registry configuration (see [below for nested schema](#nestedblock--schema_registry))
@@ -56,6 +67,40 @@ resource "doublecloud_clickhouse_kafka" "example-kafka" {
 ### Read-Only
 
 - `id` (String) Cluster Id
+
+<a id="nestedblock--access"></a>
+### Nested Schema for `access`
+
+Optional:
+
+- `data_services` (List of String) List of allowed services
+- `ipv4_cidr_blocks` (Attributes List) (see [below for nested schema](#nestedatt--access--ipv4_cidr_blocks))
+- `ipv6_cidr_blocks` (Attributes List) (see [below for nested schema](#nestedatt--access--ipv6_cidr_blocks))
+
+<a id="nestedatt--access--ipv4_cidr_blocks"></a>
+### Nested Schema for `access.ipv4_cidr_blocks`
+
+Required:
+
+- `value` (String) CIDR block
+
+Optional:
+
+- `description` (String) Description of CIDR block
+
+
+<a id="nestedatt--access--ipv6_cidr_blocks"></a>
+### Nested Schema for `access.ipv6_cidr_blocks`
+
+Required:
+
+- `value` (String) CIDR block
+
+Optional:
+
+- `description` (String) Description of CIDR block
+
+
 
 <a id="nestedblock--resources"></a>
 ### Nested Schema for `resources`
@@ -82,3 +127,5 @@ Required:
 Optional:
 
 - `enabled` (Boolean)
+
+

--- a/docs/resources/network.md
+++ b/docs/resources/network.md
@@ -70,3 +70,5 @@ Required:
 - `project_name` (String) Name of a project where is an imported network is located
 - `service_account_email` (String) Service account email
 - `subnetwork_name` (String) Name of a subnetwork to import
+
+

--- a/docs/resources/network_connection.md
+++ b/docs/resources/network_connection.md
@@ -134,3 +134,5 @@ Required:
 Read-Only:
 
 - `managed_network_url` (String) The URL of the managed GCP network
+
+

--- a/docs/resources/network_connection_accepter.md
+++ b/docs/resources/network_connection_accepter.md
@@ -18,3 +18,5 @@ Network Connection Accepter resource
 ### Required
 
 - `id` (String) Network Connection identifier
+
+

--- a/docs/resources/transfer.md
+++ b/docs/resources/transfer.md
@@ -20,6 +20,17 @@ resource "doublecloud_transfer" "sample-pg2ch" {
   target = doublecloud_transfer_endpoint.sample-pg2ch-target.id
   type = "SNAPSHOT_ONLY"
   activated = false
+  transformation = {
+    transformers = [
+      {
+        dbt = {
+          git_repository_link = "https://github.com/doublecloud/tests-clickhouse-dbt.git"
+          profile_name = "my_clickhouse_profile"
+          operation = "run"
+        }
+      },
+    ]
+  }
 }
 ```
 
@@ -37,8 +48,101 @@ resource "doublecloud_transfer" "sample-pg2ch" {
 
 - `activated` (Boolean) Activation of transfer
 - `description` (String) Description
+- `transformation` (Attributes) (see [below for nested schema](#nestedatt--transformation))
 - `type` (String) Transfer type
 
 ### Read-Only
 
 - `id` (String) Transfer id
+
+<a id="nestedatt--transformation"></a>
+### Nested Schema for `transformation`
+
+Optional:
+
+- `transformers` (Attributes List) (see [below for nested schema](#nestedatt--transformation--transformers))
+
+<a id="nestedatt--transformation--transformers"></a>
+### Nested Schema for `transformation.transformers`
+
+Optional:
+
+- `convert_to_string` (Attributes) Convert columns' values to strings. (see [below for nested schema](#nestedatt--transformation--transformers--convert_to_string))
+- `dbt` (Attributes) Run DBT after snapshot finish. (see [below for nested schema](#nestedatt--transformation--transformers--dbt))
+- `replace_primary_key` (Attributes) Replace the set of columns marked as PRIMARY KEYs. (see [below for nested schema](#nestedatt--transformation--transformers--replace_primary_key))
+- `table_splitter` (Attributes) Replace the name of the table to a value composed of values of columns of a row. (see [below for nested schema](#nestedatt--transformation--transformers--table_splitter))
+
+<a id="nestedatt--transformation--transformers--convert_to_string"></a>
+### Nested Schema for `transformation.transformers.convert_to_string`
+
+Optional:
+
+- `columns` (Attributes) (see [below for nested schema](#nestedatt--transformation--transformers--convert_to_string--columns))
+- `tables` (Attributes) Tables. (see [below for nested schema](#nestedatt--transformation--transformers--convert_to_string--tables))
+
+<a id="nestedatt--transformation--transformers--convert_to_string--columns"></a>
+### Nested Schema for `transformation.transformers.convert_to_string.tables`
+
+Optional:
+
+- `exclude` (List of String) Excluded columns (regular expressions). Start every name with `^` and finish with `$` to avoid unexpected side effects.
+- `include` (List of String) Included columns (regular expressions). Start every name with `^` and finish with `$` to avoid unexpected side effects.
+
+
+<a id="nestedatt--transformation--transformers--convert_to_string--tables"></a>
+### Nested Schema for `transformation.transformers.convert_to_string.tables`
+
+Optional:
+
+- `exclude` (List of String) Excluded tables (regular expressions). Start every name with `^` and finish with `$` to avoid unexpected side effects.
+- `include` (List of String) Included tables (regular expressions). Start every name with `^` and finish with `$` to avoid unexpected side effects.
+
+
+
+<a id="nestedatt--transformation--transformers--dbt"></a>
+### Nested Schema for `transformation.transformers.dbt`
+
+Optional:
+
+- `git_branch` (String) A branch or a tag of the git repository with the DBT project.
+- `git_repository_link` (String) A link to a git repository with a DBT project. Must start with `https://`. The root directory of the repository must contain a `dbt_project.yml` file.
+- `operation` (String) Operation; for example, `run`.
+- `profile_name` (String) The name for a profile which will be created automatically using the settings of the destination endpoint. The name must match the `profile` property in the `dbt_project.yml` file.
+
+
+<a id="nestedatt--transformation--transformers--replace_primary_key"></a>
+### Nested Schema for `transformation.transformers.replace_primary_key`
+
+Optional:
+
+- `keys` (List of String) Columns to mark as PRIMARY KEYs.
+- `tables` (Attributes) Tables. (see [below for nested schema](#nestedatt--transformation--transformers--replace_primary_key--tables))
+
+<a id="nestedatt--transformation--transformers--replace_primary_key--tables"></a>
+### Nested Schema for `transformation.transformers.replace_primary_key.tables`
+
+Optional:
+
+- `exclude` (List of String) Excluded tables (regular expressions). Start every name with `^` and finish with `$` to avoid unexpected side effects.
+- `include` (List of String) Included tables (regular expressions). Start every name with `^` and finish with `$` to avoid unexpected side effects.
+
+
+
+<a id="nestedatt--transformation--transformers--table_splitter"></a>
+### Nested Schema for `transformation.transformers.table_splitter`
+
+Optional:
+
+- `columns` (List of String) Columns with values to use as a new table name.
+- `splitter` (String) A string separating the parts of the new table name.
+- `tables` (Attributes) Tables. (see [below for nested schema](#nestedatt--transformation--transformers--table_splitter--tables))
+
+<a id="nestedatt--transformation--transformers--table_splitter--tables"></a>
+### Nested Schema for `transformation.transformers.table_splitter.tables`
+
+Optional:
+
+- `exclude` (List of String) Excluded tables (regular expressions). Start every name with `^` and finish with `$` to avoid unexpected side effects.
+- `include` (List of String) Included tables (regular expressions). Start every name with `^` and finish with `$` to avoid unexpected side effects.
+
+

--- a/docs/resources/transfer_endpoint.md
+++ b/docs/resources/transfer_endpoint.md
@@ -77,6 +77,8 @@ Optional:
 - `aws_cloudtrail_source` (Block, Optional) (see [below for nested schema](#nestedblock--settings--aws_cloudtrail_source))
 - `clickhouse_source` (Block, Optional) (see [below for nested schema](#nestedblock--settings--clickhouse_source))
 - `clickhouse_target` (Block, Optional) (see [below for nested schema](#nestedblock--settings--clickhouse_target))
+- `facebookmarketing_source` (Block, Optional) (see [below for nested schema](#nestedblock--settings--facebookmarketing_source))
+- `googleads_source` (Block, Optional) (see [below for nested schema](#nestedblock--settings--googleads_source))
 - `kafka_source` (Block, Optional) (see [below for nested schema](#nestedblock--settings--kafka_source))
 - `kafka_target` (Block, Optional) (see [below for nested schema](#nestedblock--settings--kafka_target))
 - `linkedinads_source` (Block, Optional) (see [below for nested schema](#nestedblock--settings--linkedinads_source))
@@ -222,6 +224,66 @@ Optional:
 
 
 
+
+
+
+<a id="nestedblock--settings--facebookmarketing_source"></a>
+### Nested Schema for `settings.facebookmarketing_source`
+
+Optional:
+
+- `access_token` (String, Sensitive) The value of the access token. See  [documentation](https://docs.airbyte.io/integrations/sources/facebook-marketing) for more information on the meaning of this token and how to obtain it
+- `account_id` (String) The Facebook Ad account ID to use when pulling data from the Facebook Marketing API. Example: `111111111111111`
+- `custom_insights` (Attributes List) Insights. Each entry must have a name and can contains `fields`, `breakdowns`, or `action_breakdowns` (see [below for nested schema](#nestedatt--settings--facebookmarketing_source--custom_insights))
+- `end_date` (String) The date until which you'd like to replicate data for all incremental streams, in the format `YYYY-MM-DDT00:00:00Z`. All data generated between `start_date` and this date will be replicated. Not setting this option will result in always syncing the latest data. Example: `2017-01-25T23:59:59Z`
+- `fetch_thumbnail_images` (Boolean) In each Ad Creative, fetch the `thumbnail_url` and store the result in `thumbnail_data_url`
+- `include_deleted` (Boolean) Include data from deleted Campaigns, Ads, and AdSets
+- `start_date` (String) The date from which to replicate data for all incremental streams, in the format `YYYY-MM-DDT00:00:00Z`. All data generated after this date and before `end_date` (if set) will be replicated. Example: `2017-01-25T00:00:00Z`
+
+<a id="nestedatt--settings--facebookmarketing_source--custom_insights"></a>
+### Nested Schema for `settings.facebookmarketing_source.custom_insights`
+
+Optional:
+
+- `action_breakdowns` (List of String) `action_breakdowns` request parameter
+- `breakdowns` (List of String) `breakdowns` request parameter
+- `fields` (List of String) `fields` request parameter
+- `name` (String) The name of the insight
+
+
+
+<a id="nestedblock--settings--googleads_source"></a>
+### Nested Schema for `settings.googleads_source`
+
+Optional:
+
+- `conversion_window_days` (Number)
+- `credentials` (Block, Optional) (see [below for nested schema](#nestedblock--settings--googleads_source--credentials))
+- `custom_queries` (Attributes List) (see [below for nested schema](#nestedatt--settings--googleads_source--custom_queries))
+- `customer_id` (String)
+- `end_date` (String)
+- `login_customer_id` (String)
+- `start_date` (String)
+
+<a id="nestedblock--settings--googleads_source--credentials"></a>
+### Nested Schema for `settings.googleads_source.credentials`
+
+Optional:
+
+- `access_token` (String)
+- `client_id` (String)
+- `client_secret` (String)
+- `developer_token` (String)
+- `refresh_token` (String)
+
+
+<a id="nestedatt--settings--googleads_source--custom_queries"></a>
+### Nested Schema for `settings.googleads_source.custom_queries`
+
+Optional:
+
+- `query` (String)
+- `table_name` (String)
 
 
 
@@ -911,3 +973,5 @@ Optional:
 - `path_prefix` (String)
 - `use_ssl` (Boolean)
 - `verify_ssl_cert` (Boolean)
+
+

--- a/docs/resources/workbook.md
+++ b/docs/resources/workbook.md
@@ -37,3 +37,5 @@ Required:
 - `config` (String) [Configuration of connection (json encoded)](https://double.cloud/docs/en/public-api/api-reference/visualization/configs/Connection)
 - `name` (String) Connection name
 - `secret` (String) Secret
+
+

--- a/examples/resources/doublecloud_clickhouse_cluster/resource.tf
+++ b/examples/resources/doublecloud_clickhouse_cluster/resource.tf
@@ -17,4 +17,14 @@ resource "doublecloud_clickhouse_cluster" "example-clickhouse" {
     log_level = "LOG_LEVEL_TRACE"
     max_connections = 120
   }
+
+  access {
+    data_services = ["transfer"]
+    ipv4_cidr_blocks = [
+      {
+        value = "10.0.0.0/8"
+        description = "Office in Berlin"
+      }
+	  ]
+  }
 }

--- a/examples/resources/doublecloud_kafka_cluster/resource.tf
+++ b/examples/resources/doublecloud_kafka_cluster/resource.tf
@@ -17,4 +17,14 @@ resource "doublecloud_clickhouse_kafka" "example-kafka" {
   schema_registry {
     enabled = false
   }
+
+  access {
+    data_services = ["transfer"]
+    ipv4_cidr_blocks = [
+      {
+        value = "10.0.0.0/8"
+        description = "Office in Berlin"
+      }
+	  ]
+  }
 }

--- a/go.sum
+++ b/go.sum
@@ -28,12 +28,6 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/doublecloud/go-genproto v0.0.0-20230804042713-1c42cd4bd90b h1:Pe5uI79s/afUpU1pkHzYQlbVI2g5Km+xejbXzURvOCI=
-github.com/doublecloud/go-genproto v0.0.0-20230804042713-1c42cd4bd90b/go.mod h1:GaWzogQ0MCW4OjW16H1DsXiKOqHXqaYsMy0wKfXwoo4=
-github.com/doublecloud/go-genproto v0.0.0-20230920040543-a4f03efd2c2f h1:QMDyr0Rx6HiayLIxSpv6lOVLgFoA3mHnC6FJD9KCYtk=
-github.com/doublecloud/go-genproto v0.0.0-20230920040543-a4f03efd2c2f/go.mod h1:GaWzogQ0MCW4OjW16H1DsXiKOqHXqaYsMy0wKfXwoo4=
-github.com/doublecloud/go-genproto v0.0.0-20230927040541-fe435efac020 h1:UvCcpaaG8pCNIz6tyFykRzQ20zDTJXgIwpjZDoCGzgg=
-github.com/doublecloud/go-genproto v0.0.0-20230927040541-fe435efac020/go.mod h1:GaWzogQ0MCW4OjW16H1DsXiKOqHXqaYsMy0wKfXwoo4=
 github.com/doublecloud/go-genproto v0.0.0-20230929140239-39308db3590f h1:P2cs07EWYoYMLcvnVz2E7wkJAFhFcpX3m8rBm5SPSkg=
 github.com/doublecloud/go-genproto v0.0.0-20230929140239-39308db3590f/go.mod h1:GaWzogQ0MCW4OjW16H1DsXiKOqHXqaYsMy0wKfXwoo4=
 github.com/doublecloud/go-sdk v0.0.0-20230922155224-1f2515f72401 h1:zfzza6JRJt2EXMRNyxe45y12WCu2/Hgod8CXgRw6ypI=

--- a/internal/provider/clickhouse_cluster_resource_test.go
+++ b/internal/provider/clickhouse_cluster_resource_test.go
@@ -34,7 +34,7 @@ func TestAccClickhouseClusterResource(t *testing.T) {
 		},
 	}
 
-	m2 := clickhouseClusterModel(m)
+	m2 := m
 	m2.Name = types.StringValue(fmt.Sprintf("%v-changed", testAccClickhouseName))
 	m2.Resources = &clickhouseClusterResources{
 		Clickhouse: &clickhouseClusterResourcesClickhouse{
@@ -57,6 +57,9 @@ func TestAccClickhouseClusterResource(t *testing.T) {
 					resource.TestCheckResourceAttr(testAccClickhouseId, "resources.clickhouse.resource_preset_id", "s1-c2-m4"),
 					resource.TestCheckResourceAttr(testAccClickhouseId, "resources.clickhouse.disk_size", "34359738368"),
 					resource.TestCheckResourceAttr(testAccClickhouseId, "config.log_level", "LOG_LEVEL_INFORMATION"),
+					resource.TestCheckResourceAttr(testAccClickhouseId, "access.data_services.0", "transfer"),
+					resource.TestCheckResourceAttr(testAccClickhouseId, "access.ipv4_cidr_blocks.0.value", "10.0.0.0/8"),
+					resource.TestCheckResourceAttr(testAccClickhouseId, "access.ipv4_cidr_blocks.0.description", "Office in Berlin"),
 				),
 			},
 			// Update and Read testing
@@ -68,6 +71,9 @@ func TestAccClickhouseClusterResource(t *testing.T) {
 					resource.TestCheckResourceAttr(testAccClickhouseId, "resources.clickhouse.disk_size", "51539607552"),
 					resource.TestCheckResourceAttr(testAccClickhouseId, "config.log_level", "LOG_LEVEL_TRACE"),
 					resource.TestCheckResourceAttr(testAccClickhouseId, "config.max_connections", "120"),
+					resource.TestCheckResourceAttr(testAccClickhouseId, "access.data_services.0", "transfer"),
+					resource.TestCheckResourceAttr(testAccClickhouseId, "access.ipv4_cidr_blocks.1.value", "11.0.0.0/8"),
+					resource.TestCheckResourceAttr(testAccClickhouseId, "access.ipv4_cidr_blocks.1.description", "Office in Cupertino"),
 				),
 			},
 			// Delete testing automatically occurs in TestCase
@@ -94,6 +100,17 @@ resource "doublecloud_clickhouse_cluster" "tf-acc-clickhouse" {
 
   config {
 	log_level = "LOG_LEVEL_INFORMATION"
+  }
+
+  access {
+	data_services = ["transfer"]
+
+	ipv4_cidr_blocks = [
+		{
+			value = "10.0.0.0/8"
+			description = "Office in Berlin"
+		}
+	]
   }
 }
 `, m.ProjectId.ValueString(),
@@ -127,6 +144,21 @@ resource "doublecloud_clickhouse_cluster" "tf-acc-clickhouse" {
   config {
 	log_level = "LOG_LEVEL_TRACE"
 	max_connections = 120
+  }
+
+  access {
+	data_services = ["transfer"]
+
+	ipv4_cidr_blocks = [
+		{
+			value = "10.0.0.0/8"
+			description = "Office in Berlin"
+		},
+		{
+			value = "11.0.0.0/8"
+			description = "Office in Cupertino"
+		}
+	]
   }
 }
 `, m.ProjectId.ValueString(),

--- a/internal/provider/clickhouse_data_source.go
+++ b/internal/provider/clickhouse_data_source.go
@@ -96,7 +96,7 @@ func clickhouseConenctionInfoSchema() map[string]schema.Attribute {
 
 func (d *ClickhouseDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Clickhouse data soruce",
+		MarkdownDescription: "Clickhouse data source",
 		Attributes: map[string]schema.Attribute{
 			"project_id": schema.StringAttribute{
 				Required:            true,

--- a/internal/provider/kafka_cluster_resource_test.go
+++ b/internal/provider/kafka_cluster_resource_test.go
@@ -13,6 +13,7 @@ import (
 
 var (
 	testAccKafkaName string = fmt.Sprintf("%v-kafka", testPrefix)
+	testAccKafkaId   string = fmt.Sprintf("doublecloud_kafka_cluster.%v", testAccKafkaName)
 )
 
 func TestAccKafkaClusterResource(t *testing.T) {
@@ -38,7 +39,7 @@ func TestAccKafkaClusterResource(t *testing.T) {
 		},
 	}
 
-	m2 := KafkaClusterModel(m)
+	m2 := m
 	m2.Name = types.StringValue("terraform-kafka-changed")
 	m2.Resources.Kafka.DiskSize = types.Int64Value(51539607552)
 
@@ -50,11 +51,13 @@ func TestAccKafkaClusterResource(t *testing.T) {
 			{
 				Config: testAccKafkaClusterResourceConfig(&m),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("doublecloud_kafka_cluster.test", "region_id", "eu-central-1"),
-					resource.TestCheckResourceAttr("doublecloud_kafka_cluster.test", "name", testAccKafkaName),
-					resource.TestCheckResourceAttr("doublecloud_kafka_cluster.test", "resources.kafka.disk_size", "34359738368"),
-					// resource.TestCheckResourceAttr("doublecloud_kafka_cluster.test", "encryption.enabled", "true"),
-					resource.TestCheckResourceAttr("doublecloud_kafka_cluster.test", "schema_registry.enabled", "false"),
+					resource.TestCheckResourceAttr(testAccKafkaId, "region_id", "eu-central-1"),
+					resource.TestCheckResourceAttr(testAccKafkaId, "name", testAccKafkaName),
+					resource.TestCheckResourceAttr(testAccKafkaId, "resources.kafka.disk_size", "34359738368"),
+					resource.TestCheckResourceAttr(testAccKafkaId, "schema_registry.enabled", "false"),
+					resource.TestCheckResourceAttr(testAccKafkaId, "access.data_services.0", "transfer"),
+					resource.TestCheckResourceAttr(testAccKafkaId, "access.ipv4_cidr_blocks.0.value", "10.0.0.0/8"),
+					resource.TestCheckResourceAttr(testAccKafkaId, "access.ipv4_cidr_blocks.0.description", "Office in Berlin"),
 				),
 			},
 			// Update and Read testing
@@ -70,9 +73,10 @@ func TestAccKafkaClusterResource(t *testing.T) {
 	})
 }
 
+//nolint:unused
 func testAccKafkaClusterResourceConfig(m *KafkaClusterModel) string {
 	return fmt.Sprintf(`
-resource "doublecloud_kafka_cluster" "test" {
+resource "doublecloud_kafka_cluster" "tf-acc-kafka" {
   project_id = %[1]q
   name = %[2]q
   region_id = %[3]q
@@ -91,6 +95,17 @@ resource "doublecloud_kafka_cluster" "test" {
   schema_registry {
 	enabled = false
   }
+
+  access {
+	data_services = ["transfer"]
+
+	ipv4_cidr_blocks = [
+		{
+			value = "10.0.0.0/8"
+			description = "Office in Berlin"
+		}
+	]
+  }
 }
 `, m.ProjectID.ValueString(),
 		m.Name.ValueString(),
@@ -107,7 +122,7 @@ resource "doublecloud_kafka_cluster" "test" {
 //nolint:unused
 func testAccKafkaClusterResourceConfigUpdated(m *KafkaClusterModel) string {
 	return fmt.Sprintf(`
-resource "doublecloud_kafka_cluster" "test" {
+resource "doublecloud_kafka_cluster" "tf-acc-kafka" {
   project_id = %[1]q
   name = %[2]q
   region_id = %[3]q
@@ -125,6 +140,17 @@ resource "doublecloud_kafka_cluster" "test" {
 
   schema_registry {
 	enabled = true
+  }
+
+  access {
+	data_services = ["transfer"]
+
+	ipv4_cidr_blocks = [
+		{
+			value = "10.0.0.0/8"
+			description = "Office in Berlin"
+		}
+	]
   }
 }
 `, m.ProjectID.ValueString(),

--- a/internal/provider/models.go
+++ b/internal/provider/models.go
@@ -1,0 +1,179 @@
+package provider
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/listvalidator"
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+
+	v1 "github.com/doublecloud/go-genproto/doublecloud/v1"
+)
+
+type AccessModel struct {
+	Ipv4CIDRBlocks []*CIDRBlock   `tfsdk:"ipv4_cidr_blocks"`
+	Ipv6CIDRBlocks []*CIDRBlock   `tfsdk:"ipv6_cidr_blocks"`
+	DataServices   []types.String `tfsdk:"data_services"`
+}
+
+type CIDRBlock struct {
+	Value       types.String `tfsdk:"value"`
+	Description types.String `tfsdk:"description"`
+}
+
+func accessDataServiceOneofValues() []string {
+	result := make([]string, 0)
+	for k, v := range v1.Access_DataService_value {
+		if v == 0 {
+			continue
+		}
+		result = append(result, strings.ToLower(strings.TrimPrefix(k, "DATA_SERVICE_")))
+	}
+	return result
+}
+
+func (m *AccessModel) convert() (*v1.Access, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	r := v1.Access{}
+	if m.DataServices != nil {
+		r.DataServices = &v1.Access_DataServiceList{}
+		r.DataServices.Values = make([]v1.Access_DataService, len(m.DataServices))
+		for i := 0; i < len(m.DataServices); i++ {
+			k := fmt.Sprintf("DATA_SERVICE_%v", strings.ToUpper(m.DataServices[i].ValueString()))
+			r.DataServices.Values[i] = v1.Access_DataService(v1.Access_DataService_value[k])
+		}
+	}
+	if m.Ipv4CIDRBlocks != nil {
+		r.Ipv4CidrBlocks = &v1.Access_CidrBlockList{}
+		r.Ipv4CidrBlocks.Values = make([]*v1.Access_CidrBlock, len(m.Ipv4CIDRBlocks))
+		for i := 0; i < len(m.Ipv4CIDRBlocks); i++ {
+			v, d := m.Ipv4CIDRBlocks[i].convert()
+			r.Ipv4CidrBlocks.Values[i] = v
+			diags.Append(d...)
+		}
+	}
+	if m.Ipv6CIDRBlocks != nil {
+		r.Ipv6CidrBlocks = &v1.Access_CidrBlockList{}
+		r.Ipv6CidrBlocks.Values = make([]*v1.Access_CidrBlock, len(m.Ipv6CIDRBlocks))
+		for i := 0; i < len(m.Ipv6CIDRBlocks); i++ {
+			v, d := m.Ipv6CIDRBlocks[i].convert()
+			r.Ipv6CidrBlocks.Values[i] = v
+			diags.Append(d...)
+		}
+	}
+	return &r, diags
+}
+
+func (m *AccessModel) parse(t *v1.Access) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	if services := t.GetDataServices(); services != nil {
+		if values := services.GetValues(); values != nil {
+			if m.DataServices == nil {
+				m.DataServices = make([]types.String, 0)
+			}
+			for i := 0; i < len(values); i++ {
+				if i >= len(m.DataServices) {
+					service := strings.ToLower(strings.TrimPrefix(values[i].String(), "DATA_SERVICE_"))
+					m.DataServices = append(m.DataServices, types.StringValue(service))
+				}
+			}
+		} else {
+			m.DataServices = nil
+		}
+	} else {
+		m.DataServices = nil
+	}
+	if ipv4 := t.GetIpv4CidrBlocks(); ipv4 != nil {
+		if values := ipv4.GetValues(); values != nil {
+			if m.Ipv4CIDRBlocks == nil {
+				m.Ipv4CIDRBlocks = make([]*CIDRBlock, 0)
+			}
+			for i, block := range values {
+				if i >= len(m.Ipv4CIDRBlocks) {
+					m.Ipv4CIDRBlocks = append(m.Ipv4CIDRBlocks, new(CIDRBlock))
+				}
+				diags.Append(m.Ipv4CIDRBlocks[i].parse(block)...)
+			}
+		} else {
+			m.Ipv4CIDRBlocks = nil
+		}
+	} else {
+		m.Ipv4CIDRBlocks = nil
+	}
+	if ipv6 := t.GetIpv6CidrBlocks(); ipv6 != nil {
+		if values := ipv6.GetValues(); values != nil {
+			if m.Ipv6CIDRBlocks == nil {
+				m.Ipv6CIDRBlocks = make([]*CIDRBlock, 0)
+			}
+			for i, block := range values {
+				if i >= len(m.Ipv6CIDRBlocks) {
+					m.Ipv6CIDRBlocks = append(m.Ipv6CIDRBlocks, new(CIDRBlock))
+				}
+				diags.Append(m.Ipv6CIDRBlocks[i].parse(block)...)
+			}
+		} else {
+			m.Ipv6CIDRBlocks = nil
+		}
+	} else {
+		m.Ipv6CIDRBlocks = nil
+	}
+
+	return diags
+}
+
+func (m *CIDRBlock) convert() (*v1.Access_CidrBlock, diag.Diagnostics) {
+	return &v1.Access_CidrBlock{
+		Value:       m.Value.ValueString(),
+		Description: m.Description.ValueString(),
+	}, nil
+}
+
+func (m *CIDRBlock) parse(v *v1.Access_CidrBlock) diag.Diagnostics {
+	var diags diag.Diagnostics
+
+	m.Value = types.StringValue(v.GetValue())
+	m.Description = types.StringValue(v.GetDescription())
+
+	return diags
+}
+
+func AccessSchemaBlock() schema.Block {
+	return schema.SingleNestedBlock{
+		Attributes: map[string]schema.Attribute{
+			"data_services": schema.ListAttribute{
+				Optional:            true,
+				MarkdownDescription: "List of allowed services",
+				ElementType:         types.StringType,
+				Validators:          []validator.List{listvalidator.ValueStringsAre(stringvalidator.OneOf(accessDataServiceOneofValues()...))},
+			},
+			"ipv4_cidr_blocks": schema.ListNestedAttribute{
+				Optional:     true,
+				NestedObject: CIDRBlockAttributeSchema(),
+			},
+			"ipv6_cidr_blocks": schema.ListNestedAttribute{
+				Optional:     true,
+				NestedObject: CIDRBlockAttributeSchema(),
+			},
+		},
+	}
+}
+
+func CIDRBlockAttributeSchema() schema.NestedAttributeObject {
+	return schema.NestedAttributeObject{
+		Attributes: map[string]schema.Attribute{
+			"value": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "CIDR block",
+			},
+			"description": schema.StringAttribute{
+				Optional:            true,
+				MarkdownDescription: "Description of CIDR block",
+			},
+		},
+	}
+}

--- a/internal/provider/transfer_endpoint_resource.go
+++ b/internal/provider/transfer_endpoint_resource.go
@@ -321,7 +321,7 @@ func transferEndpointSettings(m *TransferEndpointModel) (*transfer.EndpointSetti
 	var diag diag.Diagnostics
 
 	if m.Settings == nil {
-		diag.AddError("unknwon settings", "specify settings block for transfer_endpoint")
+		diag.AddError("unknown settings", "specify settings block for transfer_endpoint")
 		return nil, diag
 	}
 

--- a/internal/provider/workbook_resource.go
+++ b/internal/provider/workbook_resource.go
@@ -315,7 +315,7 @@ func (r *WorkbookResource) Read(ctx context.Context, req resource.ReadRequest, r
 		return
 	}
 
-	// TODO: support json comparision with null values
+	// TODO: support json comparison with null values
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)


### PR DESCRIPTION
feature: added `access` block with allow lists for  `doublecloud_clickhouse_cluster` and `doublecloud_kafka_cluster`
docs: regenerate documentation
fix: fix typos
lint: strict pin for golangci and fix additional lint issues