### PR TITLE
docs: added example for BYOC setup with ClickHouse and Apache Kafka

### DIFF
--- a/example_projects/byoc_clickhouse_kafka/.gitignore
+++ b/example_projects/byoc_clickhouse_kafka/.gitignore
@@ -1,0 +1,5 @@
+.terraform.lock.hcl
+terraform.tfstate
+terraform.tfstate.backup
+.terraform
+authorized_key.json

--- a/example_projects/byoc_clickhouse_kafka/README.md
+++ b/example_projects/byoc_clickhouse_kafka/README.md
@@ -1,0 +1,34 @@
+# Example terraform to create a transfer from PostgreSQL to ClickHouse
+
+The example in this directory illustrates how to describe ClickHouse and Apache Kafka with BYOC over AWS account.
+
+Before running `terraform apply`, replace the variables and values in the Terraform files with the appropriate ones to enable access to databases in your environment.
+
+For download all providers and modules run `terraform init`.
+
+
+## Contents
+
+### `versions.tf`
+
+Contains definition of the DoubleCloud public Terraform provider and the following important block:
+
+```ini
+provider "doublecloud" {
+  authorized_key = file("authorized_key.json")
+}
+```
+
+The `authorized_key.json` is an authentication file required to use a service account. See [DoubleCloud documentation](https://double.cloud/docs/en/public-api/tutorials/transfer-api-quickstart) for the instructions on how to obtain this file.
+
+### `variables.tf`
+
+Contains several Terraform variables. See their descriptions and usage for details.
+
+### `main.tf`
+
+Contains definitions of three resources:
+
+* `"doublecloud_network" "aws"` is the doublecloud network which is connected to BYOC AWS network
+* `"doublecloud_clickhouse_cluster" "alpha-clickhouse"` is the main ClickHouse cluster which located in your AWS profile 
+* `"doublecloud_kafka_cluster" "alpha-kafka"` is the Kafka which connected to ClickHouse through `config.kafka` block

--- a/example_projects/byoc_clickhouse_kafka/main.tf
+++ b/example_projects/byoc_clickhouse_kafka/main.tf
@@ -1,0 +1,92 @@
+resource "doublecloud_network" "aws" {
+  project_id = var.project_id
+  name       = "alpha-network"
+  region_id  = module.doublecloud-byoc.region_id
+  cloud_type = "aws"
+  aws = {
+    vpc_id       = module.doublecloud-byoc.vpc_id
+    account_id   = module.doublecloud-byoc.account_id
+    iam_role_arn = module.doublecloud-byoc.iam_role_arn
+  }
+}
+
+resource "doublecloud_clickhouse_cluster" "alpha-clickhouse" {
+  project_id = var.project_id
+  name       = "alpha-clickhouse"
+  region_id  = var.region_id
+  cloud_type = "aws"
+  network_id = resource.doublecloud_network.aws.id
+
+  resources {
+    clickhouse {
+      resource_preset_id = "s1-c2-m4"
+      disk_size          = 34359738368
+      replica_count      = 1
+    }
+  }
+
+  config {
+    log_level       = "LOG_LEVEL_TRACE"
+    max_connections = 120
+
+    kafka {
+      security_protocol = "SASL_SSL"
+      sasl_mechanism    = "SCRAM_SHA_512"
+      # sasl_username = data.doublecloud_kafka.alpha-kafka.connection_info.user
+      # sasl_password = data.doublecloud_kafka.alpha-kafka.connection_info.password
+    }
+  }
+
+  access {
+    ipv4_cidr_blocks = [
+      {
+        value       = var.ipv4_cidr
+        description = "Office in Berlin"
+      }
+    ]
+  }
+
+  depends_on = [
+    resource.doublecloud_kafka_cluster.alpha-kafka,
+    data.doublecloud_kafka.alpha-kafka
+  ]
+}
+
+resource "doublecloud_kafka_cluster" "alpha-kafka" {
+  project_id = var.project_id
+  name       = "alpha-kafka"
+  region_id  = var.region_id
+  cloud_type = "aws"
+  network_id = resource.doublecloud_network.aws.id
+
+  resources {
+    kafka {
+      resource_preset_id = "s1-c2-m4"
+      disk_size          = 34359738368
+      broker_count       = 1
+      zone_count         = 1
+    }
+  }
+
+  schema_registry {
+    enabled = false
+  }
+
+  access {
+    ipv4_cidr_blocks = [
+      {
+        value       = var.ipv4_cidr
+        description = "Office in Berlin"
+      },
+      {
+        value       = "192.168.44.0/24"
+        description = "Office in Miami"
+      }
+    ]
+  }
+}
+
+data "doublecloud_kafka" "alpha-kafka" {
+  id         = resource.doublecloud_kafka_cluster.alpha-kafka.id
+  project_id = var.project_id
+}

--- a/example_projects/byoc_clickhouse_kafka/variables.tf
+++ b/example_projects/byoc_clickhouse_kafka/variables.tf
@@ -1,0 +1,17 @@
+variable "project_id" {
+  type        = string
+  default     = "dogfood"
+  description = "ID of the DoubleCloud project in which to create resources"
+}
+
+variable "ipv4_cidr" {
+  type        = string
+  description = "CIDR of used vpc"
+  default     = "10.0.0.0/16"
+}
+
+variable "region_id" {
+  type        = string
+  description = "ID of the region in which to create resources"
+  default     = "eu-central-1"
+}

--- a/example_projects/byoc_clickhouse_kafka/versions.tf
+++ b/example_projects/byoc_clickhouse_kafka/versions.tf
@@ -1,0 +1,33 @@
+terraform {
+  required_version = ">= 1.5.5"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.51.0"
+    }
+    time = {
+      source = "hashicorp/time"
+    }
+    doublecloud = {
+      source  = "registry.terraform.io/doublecloud/doublecloud"
+      version = ">= 0.1.6"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region_id
+}
+
+
+provider "doublecloud" {
+  # See https://double.cloud/docs/en/public-api/tutorials/transfer-api-quickstart on how to obtain this file
+  authorized_key = file("authorized_key.json")
+}
+
+module "doublecloud-byoc" {
+  source  = "doublecloud/doublecloud-byoc/aws"
+  version = "1.0.2"
+
+  ipv4_cidr = var.ipv4_cidr
+}

--- a/internal/provider/clickhouse_cluster_resource.go
+++ b/internal/provider/clickhouse_cluster_resource.go
@@ -14,7 +14,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -1109,7 +1108,6 @@ func clickhouseKafkaSchemaAttributes() map[string]schema.Attribute {
 			Optional:      true,
 			Computed:      true,
 			Validators:    []validator.String{clickhouseConfigKafkaSecurityProtocolValidator()},
-			PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 		},
 		"sasl_mechanism": schema.StringAttribute{
 			Optional:   true,
@@ -1125,7 +1123,6 @@ func clickhouseKafkaSchemaAttributes() map[string]schema.Attribute {
 		},
 		"enable_ssl_certificate_verification": schema.BoolAttribute{
 			Optional:      true,
-			PlanModifiers: []planmodifier.Bool{boolplanmodifier.RequiresReplace()},
 		},
 		"max_poll_interval_ms": schema.StringAttribute{
 			Optional: true,

--- a/internal/provider/clickhouse_cluster_resource.go
+++ b/internal/provider/clickhouse_cluster_resource.go
@@ -1106,15 +1106,15 @@ func clickhouseConfigSchemaBlock() schema.Block {
 func clickhouseKafkaSchemaAttributes() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"security_protocol": schema.StringAttribute{
-			Optional:   true,
-			Computed:   true,
-			Validators: []validator.String{clickhouseConfigKafkaSecurityProtocolValidator()},
+			Optional:      true,
+			Computed:      true,
+			Validators:    []validator.String{clickhouseConfigKafkaSecurityProtocolValidator()},
 			PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 		},
 		"sasl_mechanism": schema.StringAttribute{
-			Optional:      true,
-			Computed:      true,
-			Validators:    []validator.String{clickhouseConfigKafkaSaslMechanismValidator()},
+			Optional:   true,
+			Computed:   true,
+			Validators: []validator.String{clickhouseConfigKafkaSaslMechanismValidator()},
 		},
 		"sasl_username": schema.StringAttribute{
 			Optional: true,

--- a/internal/provider/clickhouse_cluster_resource.go
+++ b/internal/provider/clickhouse_cluster_resource.go
@@ -1109,12 +1109,12 @@ func clickhouseKafkaSchemaAttributes() map[string]schema.Attribute {
 			Optional:   true,
 			Computed:   true,
 			Validators: []validator.String{clickhouseConfigKafkaSecurityProtocolValidator()},
+			PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 		},
 		"sasl_mechanism": schema.StringAttribute{
 			Optional:      true,
 			Computed:      true,
 			Validators:    []validator.String{clickhouseConfigKafkaSaslMechanismValidator()},
-			PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 		},
 		"sasl_username": schema.StringAttribute{
 			Optional: true,

--- a/internal/provider/clickhouse_cluster_resource.go
+++ b/internal/provider/clickhouse_cluster_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
@@ -1110,9 +1111,10 @@ func clickhouseKafkaSchemaAttributes() map[string]schema.Attribute {
 			Validators: []validator.String{clickhouseConfigKafkaSecurityProtocolValidator()},
 		},
 		"sasl_mechanism": schema.StringAttribute{
-			Optional:   true,
-			Computed:   true,
-			Validators: []validator.String{clickhouseConfigKafkaSaslMechanismValidator()},
+			Optional:      true,
+			Computed:      true,
+			Validators:    []validator.String{clickhouseConfigKafkaSaslMechanismValidator()},
+			PlanModifiers: []planmodifier.String{stringplanmodifier.RequiresReplace()},
 		},
 		"sasl_username": schema.StringAttribute{
 			Optional: true,
@@ -1122,7 +1124,8 @@ func clickhouseKafkaSchemaAttributes() map[string]schema.Attribute {
 			Sensitive: true,
 		},
 		"enable_ssl_certificate_verification": schema.BoolAttribute{
-			Optional: true,
+			Optional:      true,
+			PlanModifiers: []planmodifier.Bool{boolplanmodifier.RequiresReplace()},
 		},
 		"max_poll_interval_ms": schema.StringAttribute{
 			Optional: true,

--- a/internal/provider/clickhouse_cluster_resource.go
+++ b/internal/provider/clickhouse_cluster_resource.go
@@ -1105,9 +1105,9 @@ func clickhouseConfigSchemaBlock() schema.Block {
 func clickhouseKafkaSchemaAttributes() map[string]schema.Attribute {
 	return map[string]schema.Attribute{
 		"security_protocol": schema.StringAttribute{
-			Optional:      true,
-			Computed:      true,
-			Validators:    []validator.String{clickhouseConfigKafkaSecurityProtocolValidator()},
+			Optional:   true,
+			Computed:   true,
+			Validators: []validator.String{clickhouseConfigKafkaSecurityProtocolValidator()},
 		},
 		"sasl_mechanism": schema.StringAttribute{
 			Optional:   true,
@@ -1122,7 +1122,7 @@ func clickhouseKafkaSchemaAttributes() map[string]schema.Attribute {
 			Sensitive: true,
 		},
 		"enable_ssl_certificate_verification": schema.BoolAttribute{
-			Optional:      true,
+			Optional: true,
 		},
 		"max_poll_interval_ms": schema.StringAttribute{
 			Optional: true,


### PR DESCRIPTION
docs: added example for BYOC setup with ClickHouse and Apache Kafka
fix: delete RequireReplace for kafka fields in `doublecloud_clickhouse_cluster`