### PR TITLE
feature: `connection_info`

### DIFF
--- a/internal/provider/kafka_cluster_resource.go
+++ b/internal/provider/kafka_cluster_resource.go
@@ -8,10 +8,12 @@ import (
 	dcsdk "github.com/doublecloud/go-sdk"
 	dcgen "github.com/doublecloud/go-sdk/gen/kafka"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -37,17 +39,19 @@ type KafkaClusterResource struct {
 }
 
 type KafkaClusterModel struct {
-	Id             types.String         `tfsdk:"id"`
-	ProjectID      types.String         `tfsdk:"project_id"`
-	CloudType      types.String         `tfsdk:"cloud_type"`
-	RegionID       types.String         `tfsdk:"region_id"`
-	Name           types.String         `tfsdk:"name"`
-	Description    types.String         `tfsdk:"description"`
-	Version        types.String         `tfsdk:"version"`
-	Resources      KafkaResourcesModel  `tfsdk:"resources"`
-	NetworkId      types.String         `tfsdk:"network_id"`
-	SchemaRegistry *schemaRegistryModel `tfsdk:"schema_registry"`
-	Access         *AccessModel         `tfsdk:"access"`
+	Id                    types.String         `tfsdk:"id"`
+	ProjectID             types.String         `tfsdk:"project_id"`
+	CloudType             types.String         `tfsdk:"cloud_type"`
+	RegionID              types.String         `tfsdk:"region_id"`
+	Name                  types.String         `tfsdk:"name"`
+	Description           types.String         `tfsdk:"description"`
+	Version               types.String         `tfsdk:"version"`
+	Resources             KafkaResourcesModel  `tfsdk:"resources"`
+	NetworkId             types.String         `tfsdk:"network_id"`
+	SchemaRegistry        *schemaRegistryModel `tfsdk:"schema_registry"`
+	Access                *AccessModel         `tfsdk:"access"`
+	ConnectionInfo        types.Object         `tfsdk:"connection_info"`
+	PrivateConnectionInfo types.Object         `tfsdk:"private_connection_info"`
 }
 
 type schemaRegistryModel struct {
@@ -121,6 +125,16 @@ func (r *KafkaClusterResource) Schema(ctx context.Context, req resource.SchemaRe
 				Computed:            true,
 				MarkdownDescription: "Version of Apache Kafka",
 				PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+			},
+			"connection_info": schema.SingleNestedAttribute{
+				Computed:      true,
+				Attributes:    kafkaConnectionInfoResSchema(),
+				PlanModifiers: []planmodifier.Object{objectplanmodifier.UseStateForUnknown()},
+			},
+			"private_connection_info": schema.SingleNestedAttribute{
+				Computed:      true,
+				Attributes:    kafkaConnectionInfoResSchema(),
+				PlanModifiers: []planmodifier.Object{objectplanmodifier.UseStateForUnknown()},
 			},
 		},
 		Blocks: map[string]schema.Block{
@@ -268,6 +282,36 @@ func (r *KafkaClusterResource) Create(ctx context.Context, req resource.CreateRe
 		return
 	}
 	data.Version = types.StringValue(cluster.Version)
+	if info := cluster.GetConnectionInfo(); info != nil {
+		o, d := types.ObjectValue(map[string]attr.Type{
+			"connection_string": types.StringType,
+			"user":              types.StringType,
+			"password":          types.StringType,
+		},
+			map[string]attr.Value{
+				"connection_string": types.StringValue(info.GetConnectionString()),
+				"user":              types.StringValue(info.GetUser()),
+				"password":          types.StringValue(info.GetPassword()),
+			},
+		)
+		resp.Diagnostics.Append(d...)
+		data.ConnectionInfo = o
+	}
+	if info := cluster.GetPrivateConnectionInfo(); info != nil {
+		o, d := types.ObjectValue(map[string]attr.Type{
+			"connection_string": types.StringType,
+			"user":              types.StringType,
+			"password":          types.StringType,
+		},
+			map[string]attr.Value{
+				"connection_string": types.StringValue(info.GetConnectionString()),
+				"user":              types.StringValue(info.GetUser()),
+				"password":          types.StringValue(info.GetPassword()),
+			},
+		)
+		resp.Diagnostics.Append(d...)
+		data.PrivateConnectionInfo = o
+	}
 
 	tflog.Info(ctx, fmt.Sprintf("doublecloud_kafka_cluster has been created: %s", op.ResourceId()))
 
@@ -279,7 +323,10 @@ func getKafkaClusterResourceRequest(m *KafkaClusterModel) (*kafka.GetClusterRequ
 	if m.Id == types.StringNull() {
 		return nil, diag.Diagnostics{diag.NewErrorDiagnostic("Unknown identifier", "missed one of required fields: cluster_id or name")}
 	}
-	return &kafka.GetClusterRequest{ClusterId: m.Id.ValueString()}, nil
+	return &kafka.GetClusterRequest{
+		ClusterId: m.Id.ValueString(),
+		Sensitive: true,
+	}, nil
 }
 
 func (r *KafkaClusterResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
@@ -315,6 +362,39 @@ func (r *KafkaClusterResource) Read(ctx context.Context, req resource.ReadReques
 
 	if rs.SchemaRegistryConfig != nil {
 		data.SchemaRegistry = &schemaRegistryModel{Enabled: types.BoolValue(rs.SchemaRegistryConfig.Enabled)}
+	} else {
+		data.SchemaRegistry = nil
+	}
+
+	if info := rs.GetConnectionInfo(); info != nil {
+		o, d := types.ObjectValue(map[string]attr.Type{
+			"connection_string": types.StringType,
+			"user":              types.StringType,
+			"password":          types.StringType,
+		},
+			map[string]attr.Value{
+				"connection_string": types.StringValue(info.GetConnectionString()),
+				"user":              types.StringValue(info.GetUser()),
+				"password":          types.StringValue(info.GetPassword()),
+			},
+		)
+		resp.Diagnostics.Append(d...)
+		data.ConnectionInfo = o
+	}
+	if info := rs.GetPrivateConnectionInfo(); info != nil {
+		o, d := types.ObjectValue(map[string]attr.Type{
+			"connection_string": types.StringType,
+			"user":              types.StringType,
+			"password":          types.StringType,
+		},
+			map[string]attr.Value{
+				"connection_string": types.StringValue(info.GetConnectionString()),
+				"user":              types.StringValue(info.GetUser()),
+				"password":          types.StringValue(info.GetPassword()),
+			},
+		)
+		resp.Diagnostics.Append(d...)
+		data.PrivateConnectionInfo = o
 	}
 
 	// Save updated data into Terraform state
@@ -417,4 +497,24 @@ func (r *KafkaClusterResource) Delete(ctx context.Context, req resource.DeleteRe
 
 func (r *KafkaClusterResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+func kafkaConnectionInfoResSchema() map[string]schema.Attribute {
+	return map[string]schema.Attribute{
+		"connection_string": schema.StringAttribute{
+			Computed:            true,
+			MarkdownDescription: "String to use in clients",
+			PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+		},
+		"user": schema.StringAttribute{
+			Computed:            true,
+			MarkdownDescription: "Apache Kafka® user",
+			PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+		},
+		"password": schema.StringAttribute{
+			Computed:            true,
+			MarkdownDescription: "Password for Apache Kafka® user",
+			PlanModifiers:       []planmodifier.String{stringplanmodifier.UseStateForUnknown()},
+		},
+	}
 }

--- a/internal/provider/kafka_cluster_resource_test.go
+++ b/internal/provider/kafka_cluster_resource_test.go
@@ -55,9 +55,18 @@ func TestAccKafkaClusterResource(t *testing.T) {
 					resource.TestCheckResourceAttr(testAccKafkaId, "name", testAccKafkaName),
 					resource.TestCheckResourceAttr(testAccKafkaId, "resources.kafka.disk_size", "34359738368"),
 					resource.TestCheckResourceAttr(testAccKafkaId, "schema_registry.enabled", "false"),
+
 					resource.TestCheckResourceAttr(testAccKafkaId, "access.data_services.0", "transfer"),
 					resource.TestCheckResourceAttr(testAccKafkaId, "access.ipv4_cidr_blocks.0.value", "10.0.0.0/8"),
 					resource.TestCheckResourceAttr(testAccKafkaId, "access.ipv4_cidr_blocks.0.description", "Office in Berlin"),
+
+					resource.TestCheckResourceAttrSet(testAccKafkaId, "connection_info.connection_string"),
+					resource.TestCheckResourceAttr(testAccKafkaId, "connection_info.user", "admin"),
+					resource.TestCheckResourceAttrSet(testAccKafkaId, "connection_info.password"),
+
+					resource.TestCheckResourceAttrSet(testAccKafkaId, "private_connection_info.connection_string"),
+					resource.TestCheckResourceAttr(testAccKafkaId, "private_connection_info.user", "admin"),
+					resource.TestCheckResourceAttrSet(testAccKafkaId, "private_connection_info.password"),
 				),
 			},
 			// Update and Read testing


### PR DESCRIPTION
feature: add `connection_info` and `private_connection_info` as computed fields for `doublecloud_kafka_cluster`